### PR TITLE
move staggering into site getevents worker

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module cron-control-runner
+module github.com/Automattic/cron-control-runner
 
 go 1.17
 

--- a/main.go
+++ b/main.go
@@ -1,13 +1,14 @@
 package main
 
 import (
-	"cron-control-runner/logger"
-	"cron-control-runner/metrics"
-	"cron-control-runner/orchestrator"
-	"cron-control-runner/performer"
-	"cron-control-runner/remote"
 	"flag"
+	"github.com/Automattic/cron-control-runner/logger"
+	"github.com/Automattic/cron-control-runner/metrics"
+	"github.com/Automattic/cron-control-runner/orchestrator"
+	"github.com/Automattic/cron-control-runner/performer"
+	"github.com/Automattic/cron-control-runner/remote"
 	"log"
+	"math/rand"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -28,6 +29,8 @@ type options struct {
 }
 
 func main() {
+	rand.Seed(time.Now().UnixNano())
+
 	// Listen for termination signals.
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)

--- a/orchestrator/orchestrator.go
+++ b/orchestrator/orchestrator.go
@@ -1,10 +1,11 @@
 package orchestrator
 
 import (
-	"cron-control-runner/logger"
-	"cron-control-runner/metrics"
-	"cron-control-runner/performer"
 	"fmt"
+	"github.com/Automattic/cron-control-runner/logger"
+	"github.com/Automattic/cron-control-runner/metrics"
+	"github.com/Automattic/cron-control-runner/performer"
+	"math/rand"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -124,8 +125,6 @@ func (orch *Orchestrator) manageSiteWatchers(watchedSites threadTracker) threadT
 
 	// Start up individual goroutines per each site we need to be watching.
 	for _, site := range sitesToWatch {
-		stutterWatchers(len(sitesToWatch), orch.config.GetEventsInterval)
-
 		orch.logger.Debugf("starting thread %q", site.URL)
 		closeChan := make(chan struct{})
 		watchedSites[site.URL] = closeChan
@@ -143,8 +142,26 @@ func (orch *Orchestrator) manageSiteWatchers(watchedSites threadTracker) threadT
  * B) the events that were fetched won't grow super stale while waiting to be pushed into the events queue
  */
 func (orch *Orchestrator) startSiteWatcher(site site, close chan struct{}) {
+	initialDelay := time.Duration(rand.Int63()) % orch.config.GetEventsInterval
+	orch.logger.Infof("starting watcher for site %+v, initial delay: %v", site, initialDelay)
+	select {
+	case <-close:
+		return // closed while waiting for initial delay
+	case <-time.After(initialDelay):
+		orch.logger.Debugf("initial delay has elapsed for %+v, starting to run events", site)
+	}
+
 	ticker := time.NewTicker(orch.config.GetEventsInterval)
 	defer ticker.Stop()
+
+	// initial fetch, does not wait for ticker's first firing.
+	select {
+	case <-close:
+		return // closed while waiting for semaphore
+	case orch.semGetEvents <- true:
+		// we have acquired the semaphore
+		orch.fetchSiteEvents(site, close)
+	}
 
 	for {
 		select {
@@ -264,17 +281,6 @@ func checkForSiteDiffs(watchedSites threadTracker, newSites sites) (sitesToAdd s
 	}
 
 	return sitesToAdd, sitesToRemove
-}
-
-// Evenly spread the site tickers between the configured interval.
-// Example: 10 subsites w/ 60s intervals would result in each site pausing here for 6 seconds.
-func stutterWatchers(numberOfSites int, getEventsInterval time.Duration) {
-	if numberOfSites == 1 {
-		return
-	}
-
-	stutterDuration := getEventsInterval.Seconds() / float64(numberOfSites)
-	time.Sleep(time.Duration(stutterDuration) * time.Second)
 }
 
 // Quickly send close signals to all tracked threads.

--- a/orchestrator/orchestrator.go
+++ b/orchestrator/orchestrator.go
@@ -86,17 +86,16 @@ func (orch *Orchestrator) setupWatchers() error {
 	ticker := time.NewTicker(orch.config.GetSitesInterval)
 	defer ticker.Stop()
 
-	for keepRunning := true; keepRunning; {
+	for {
 		select {
 		case <-orch.tomb.Dying():
 			orch.logger.Infof("orchestrator is shutting down, stopping watchers")
-			keepRunning = false
+			// return from the outer function, triggers defer(s) to cleanup.
+			return nil
 		case <-ticker.C:
 			watchedSites = orch.manageSiteWatchers(watchedSites)
 		}
 	}
-
-	return nil
 }
 
 // Starts up watchers for new sites, removes watchers for unlisted sites.

--- a/performer/cli.go
+++ b/performer/cli.go
@@ -1,10 +1,10 @@
 package performer
 
 import (
-	"cron-control-runner/logger"
-	"cron-control-runner/metrics"
 	"encoding/json"
 	"fmt"
+	"github.com/Automattic/cron-control-runner/logger"
+	"github.com/Automattic/cron-control-runner/metrics"
 	"io"
 	"math/rand"
 	"net/http"


### PR DESCRIPTION
This PR moves the staggering of initial fetches into the worker routine, so it does not thread.Sleep in the orchestrator. The delay is random between `[0, getEventsInterval)`. it then immediately fetches events and starts a ticker.

ALSO:

1. Fixes modules
2. Seed the PRNG at atartup

```
2021/11/15 10:37:30 INFO: starting watcher for site {URL:example4.com}, initial delay: 2.069834858s
2021/11/15 10:37:30 INFO: starting watcher for site {URL:example5.com}, initial delay: 26.334903369s
2021/11/15 10:37:30 INFO: starting watcher for site {URL:example6.com}, initial delay: 12.893817754s
2021/11/15 10:37:30 INFO: starting watcher for site {URL:example7.com}, initial delay: 859.284141ms
2021/11/15 10:37:31 DEBUG: initial delay has elapsed for {URL:example7.com}, starting to run events
2021/11/15 10:37:32 DEBUG: initial delay has elapsed for {URL:example4.com}, starting to run events
...

```