### PR TITLE
performer readiness check

### DIFF
--- a/main.go
+++ b/main.go
@@ -53,7 +53,7 @@ func main() {
 	var perf performer.Performer
 	if options.useMockData {
 		logger.Infof("Using Mock Performer")
-		perf = performer.Mock{UseSleeps: true, LogCommands: false, RotateSites: true}
+		perf = &performer.Mock{UseSleeps: true, LogCommands: false, RotateSites: true}
 	} else {
 		perf = performer.NewCLI(options.wpCLIPath, options.wpPath, options.fpmURL, metricsManager, logger)
 	}

--- a/orchestrator/orchestrator.go
+++ b/orchestrator/orchestrator.go
@@ -76,6 +76,16 @@ func (orch *Orchestrator) Close() error {
  *   2) For every site we are responsible for tracking, spin up a site watcher.
  */
 func (orch *Orchestrator) setupWatchers() error {
+	for !orch.performer.IsReady() {
+		select {
+		case <-orch.tomb.Dying():
+			orch.logger.Infof("orchestrator is shutting down, performer was never ready")
+			return nil
+		case <-time.After(1*time.Second):
+			orch.logger.Debugf("testing performer readiness")
+		}
+	}
+
 	watchedSites := make(threadTracker)
 	defer closeTrackedThreads(watchedSites)
 

--- a/performer/mock.go
+++ b/performer/mock.go
@@ -5,17 +5,21 @@ import (
 	"time"
 )
 
+var _ Performer = &Mock{}
 // Mock is a fake performer, gives example data back. Useful for testing orchestrator changes.
 type Mock struct {
+	rotation int
 	UseSleeps   bool
 	LogCommands bool
 	RotateSites bool
 }
 
-var rotation = 0
+func (perf *Mock) IsReady() bool {
+	return true
+}
 
 // GetSites fetches a mocked list of sites.
-func (perf Mock) GetSites(_ time.Duration) (Sites, error) {
+func (perf *Mock) GetSites(_ time.Duration) (Sites, error) {
 	if perf.UseSleeps {
 		// mock remote calltime
 		time.Sleep(1 * time.Second)
@@ -33,17 +37,17 @@ func (perf Mock) GetSites(_ time.Duration) (Sites, error) {
 
 	if perf.RotateSites {
 		// Simulate sites changing. Though uncommon, good to test w/ it.
-		rotation = rotation + 1
-		if rotation > 2 {
-			rotation = 0
+		perf.rotation = perf.rotation + 1
+		if perf.rotation > 2 {
+			perf.rotation = 0
 		}
 	}
 
-	if rotation == 0 {
+	if perf.rotation == 0 {
 		slice = siteURLs[0:4]
-	} else if rotation == 1 {
+	} else if perf.rotation == 1 {
 		slice = siteURLs[3:7]
-	} else if rotation == 2 {
+	} else if perf.rotation == 2 {
 		slice = siteURLs[5:9]
 	}
 
@@ -56,7 +60,7 @@ func (perf Mock) GetSites(_ time.Duration) (Sites, error) {
 }
 
 // GetEvents returns a mocked list of events.
-func (perf Mock) GetEvents(site Site) ([]Event, error) {
+func (perf *Mock) GetEvents(site Site) ([]Event, error) {
 	if perf.UseSleeps {
 		time.Sleep(2 * time.Second)
 	}
@@ -75,7 +79,7 @@ func (perf Mock) GetEvents(site Site) ([]Event, error) {
 }
 
 // RunEvent mocks the running of an event.
-func (perf Mock) RunEvent(event Event) error {
+func (perf *Mock) RunEvent(event Event) error {
 	if perf.UseSleeps {
 		time.Sleep(5 * time.Second)
 	}

--- a/performer/performer.go
+++ b/performer/performer.go
@@ -8,6 +8,7 @@ import (
 // Performer is responsible for the real interaction w/ sites.
 // It does the event fetching and running, be that through wp cli, php-fpm, or rest apis.
 type Performer interface {
+	IsReady() bool
 	GetSites(time.Duration) (Sites, error)
 	GetEvents(site Site) ([]Event, error)
 	RunEvent(event Event) error


### PR DESCRIPTION
If the cron runner starts up before FPM, we have to wait the full `get-sites-interval` (60s) to try again.

This adds an `IsReady() bool` method to performers, and we will check it every second on startup until it reports being ready.