### PR TITLE
add locker + memcache implementation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/Automattic/cron-control-runner
 go 1.17
 
 require (
+	github.com/bradfitz/gomemcache v0.0.0-20190913173617-a41fca850d0b
 	github.com/creack/pty v1.1.17
 	github.com/howeyc/fsnotify v0.9.0
 	github.com/prometheus/client_golang v1.11.0
@@ -14,7 +15,6 @@ require (
 
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/bradfitz/gomemcache v0.0.0-20190913173617-a41fca850d0b // indirect
 	github.com/cespare/xxhash/v2 v2.1.1 // indirect
 	github.com/golang/protobuf v1.4.3 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/bradfitz/gomemcache v0.0.0-20190913173617-a41fca850d0b // indirect
 	github.com/cespare/xxhash/v2 v2.1.1 // indirect
 	github.com/golang/protobuf v1.4.3 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/bradfitz/gomemcache v0.0.0-20190913173617-a41fca850d0b h1:L/QXpzIa3pOvUGt1D1lA5KjYhPBAN/3iWdP7xeFS9F0=
+github.com/bradfitz/gomemcache v0.0.0-20190913173617-a41fca850d0b/go.mod h1:H0wQNHz2YrLsuXOZozoeDmnHXkNCRmMW0gwFWDfEZDA=
 github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/creack/pty v1.1.17 h1:QeVUsEDNrLBW4tMgZHvxy18sKtr6VI492kBhUfhDJNI=

--- a/locker/locker.go
+++ b/locker/locker.go
@@ -7,9 +7,13 @@ import (
 
 var ErrAlreadyLocked = errors.New("already locked")
 
+type Lockable interface {
+	LockKey() string
+}
+
 type Locker interface {
 	io.Closer
-	Lock(id string) (Lock, error)
+	Lock(Lockable) (Lock, error)
 }
 
 type Lock interface {

--- a/locker/locker.go
+++ b/locker/locker.go
@@ -1,0 +1,17 @@
+package locker
+
+import (
+	"errors"
+	"io"
+)
+
+var ErrAlreadyLocked = errors.New("already locked")
+
+type Locker interface {
+	io.Closer
+	Lock(id string) (Lock, error)
+}
+
+type Lock interface {
+	Unlock()
+}

--- a/locker/memcache.go
+++ b/locker/memcache.go
@@ -1,0 +1,161 @@
+package locker
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/Automattic/cron-control-runner/logger"
+	"github.com/bradfitz/gomemcache/memcache"
+	"os"
+	"sort"
+	"time"
+)
+
+var _ Locker = &memcacheLocker{}
+
+type memcacheLocker struct {
+	Log             logger.Logger
+	KeyPrefix       string
+	ConfigPath      string
+	ServerList      *memcache.ServerList
+	Client          *memcache.Client
+	LeaseInterval   time.Duration
+	RefreshInterval time.Duration
+	CloseChan       chan struct{}
+}
+
+func NewMemcache(log logger.Logger, keyPrefix, configPath string, leaseInterval, refreshInterval time.Duration) Locker {
+	res := &memcacheLocker{
+		KeyPrefix:       keyPrefix,
+		Log:             log,
+		ConfigPath:      configPath,
+		ServerList:      &memcache.ServerList{},
+		LeaseInterval:   leaseInterval,
+		RefreshInterval: refreshInterval,
+		CloseChan:       make(chan struct{}),
+	}
+	res.Client = memcache.NewFromSelector(res.ServerList)
+	res.tryReloadConfig()
+	go res.runConfigReloader()
+	return res
+}
+
+func (m *memcacheLocker) Close() error {
+	close(m.CloseChan)
+	return nil
+}
+
+var myHostname = []byte((func() string {
+	hostname, err := os.Hostname()
+	if err != nil {
+		return "unknown"
+	}
+	return hostname
+})())
+
+func (m *memcacheLocker) Lock(id string) (Lock, error) {
+	item := &memcache.Item{
+		Key:        fmt.Sprintf("%s%s", m.KeyPrefix, id),
+		Value:      myHostname, // we put the hostname of the lock owner as the value of the key
+		Flags:      0,
+		Expiration: int32(m.LeaseInterval.Seconds()),
+	}
+	if err := m.Client.Add(item); err == nil {
+		// success!
+		lock := &memcacheLock{
+			Item:      item,
+			Owner:     m,
+			CloseChan: make(chan struct{}),
+		}
+		go lock.runKeepalive()
+		return lock, nil
+	} else if err == memcache.ErrNotStored {
+		return nil, ErrAlreadyLocked
+	} else {
+		return nil, nil
+	}
+}
+
+var _ Lock = &memcacheLock{}
+
+type memcacheLock struct {
+	Item      *memcache.Item
+	Owner     *memcacheLocker
+	CloseChan chan struct{}
+}
+
+func (m *memcacheLock) Unlock() {
+	close(m.CloseChan) // stop keepalive thread
+}
+
+func (m *memcacheLock) runKeepalive() {
+	ticker := time.NewTicker(m.Owner.LeaseInterval / 2)
+	defer ticker.Stop()
+	defer (func() {
+		if err := m.Owner.Client.Delete(m.Item.Key); err != nil && err != memcache.ErrCacheMiss {
+			m.Owner.Log.Errorf("failed to release memcache lock on %q: %v", m.Item.Key, err)
+		}
+	})()
+	for {
+		select {
+		case <-m.CloseChan:
+			return
+		case <-ticker.C:
+			// time to extend our lease!
+			m.Owner.Log.Debugf("extending memcache lease on %q", m.Item.Key)
+			if err := m.Owner.Client.Touch(m.Item.Key, m.Item.Expiration); err == memcache.ErrCacheMiss {
+				m.Owner.Log.Errorf("failed to extend memcache lease on %q: %v", m.Item.Key, err)
+				return
+			}
+		}
+	}
+}
+
+func (m *memcacheLocker) runConfigReloader() {
+	ticker := time.NewTicker(m.RefreshInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-m.CloseChan:
+			return
+		case <-ticker.C:
+			m.tryReloadConfig()
+		}
+	}
+}
+
+func (m *memcacheLocker) tryReloadConfig() {
+	m.Log.Debugf("reloading memcache config")
+	if err := m.reloadConfig(); err != nil {
+		m.Log.Errorf("failed to reload memcache config: %v", err)
+	}
+}
+
+func (m *memcacheLocker) reloadConfig() error {
+	f, err := os.Open(m.ConfigPath)
+	if err != nil {
+		return err
+	}
+	defer (func() { _ = f.Close() })()
+	var dc DataConfig
+	if err = json.NewDecoder(f).Decode(&dc); err != nil {
+		return err
+	}
+	servers := make([]string, len(dc.Memcache))
+	for i, mcs := range dc.Memcache {
+		servers[i] = fmt.Sprintf("%s:%d", mcs.Host, mcs.Port)
+	}
+	sort.Strings(servers)
+	if err = m.ServerList.SetServers(servers...); err != nil {
+		return err
+	}
+	return nil
+}
+
+type DataConfig struct {
+	Memcache []MemcacheClientConfig `json:"memcache"`
+}
+
+type MemcacheClientConfig struct {
+	Host string `json:"host"`
+	Port int    `json:"port"`
+}

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -9,6 +9,7 @@ type Manager interface {
 	RecordGetSites(isSuccess bool, elapsed time.Duration)
 	RecordGetSiteEvents(isSuccess bool, elapsed time.Duration, siteURL string, numEvents int)
 	RecordRunEvent(isSuccess bool, elapsed time.Duration, siteURL string, reason string)
+	RecordLockEvent(url string, status string)
 	RecordRunWorkerStats(currBusy int32, max int32)
 	RecordFpmTiming(isSuccess bool, elapsed time.Duration)
 }

--- a/metrics/mock.go
+++ b/metrics/mock.go
@@ -10,6 +10,12 @@ type Mock struct {
 	Log bool
 }
 
+func (m Mock) RecordLockEvent(url string, status string) {
+	if m.Log {
+		log.Printf("metrics: RecordLockEvent(url: %s, status: %s)", url, status)
+	}
+}
+
 // RecordGetSites tracks successful performer.GetSites() calls.
 func (m Mock) RecordGetSites(isSuccess bool, elapsed time.Duration) {
 	if m.Log {

--- a/orchestrator/orchestrator.go
+++ b/orchestrator/orchestrator.go
@@ -256,7 +256,7 @@ func (orch *Orchestrator) startEventRunner(workerID string, close chan struct{},
 			var lock locker.Lock
 			var err error
 			if orch.locker != nil {
-				if lock, err = orch.locker.Lock(runnableEvent.Hash()); err == nil {
+				if lock, err = orch.locker.Lock(runnableEvent); err == nil {
 					if lock == nil {
 						orch.metrics.RecordLockEvent(runnableEvent.URL, "not_locked")
 					} else {

--- a/orchestrator/orchestrator.go
+++ b/orchestrator/orchestrator.go
@@ -2,6 +2,7 @@ package orchestrator
 
 import (
 	"fmt"
+	"github.com/Automattic/cron-control-runner/locker"
 	"github.com/Automattic/cron-control-runner/logger"
 	"github.com/Automattic/cron-control-runner/metrics"
 	"github.com/Automattic/cron-control-runner/performer"
@@ -21,6 +22,7 @@ type Orchestrator struct {
 	performer        performer.Performer
 	metrics          metrics.Manager
 	logger           logger.Logger
+	locker           locker.Locker
 	tomb             tomb.Tomb
 	semGetEvents     chan bool
 	busyEventWorkers int32
@@ -43,7 +45,7 @@ type event = performer.Event
 type threadTracker map[string]chan struct{}
 
 // New sets up a new orchestrator based on the passed configurations
-func New(perf performer.Performer, metrics metrics.Manager, logger logger.Logger, config Config) *Orchestrator {
+func New(perf performer.Performer, metrics metrics.Manager, logger logger.Logger, locker locker.Locker, config Config) *Orchestrator {
 	config = sanitizeConfig(config)
 	orchestrator := &Orchestrator{
 		events:       make(chan event, config.EventBacklog),
@@ -51,6 +53,7 @@ func New(perf performer.Performer, metrics metrics.Manager, logger logger.Logger
 		performer:    perf,
 		metrics:      metrics,
 		logger:       logger,
+		locker:       locker,
 		semGetEvents: make(chan bool, config.GetEventsParallelism),
 	}
 
@@ -81,7 +84,7 @@ func (orch *Orchestrator) setupWatchers() error {
 		case <-orch.tomb.Dying():
 			orch.logger.Infof("orchestrator is shutting down, performer was never ready")
 			return nil
-		case <-time.After(1*time.Second):
+		case <-time.After(1 * time.Second):
 			orch.logger.Debugf("testing performer readiness")
 		}
 	}
@@ -247,29 +250,41 @@ func (orch *Orchestrator) startEventRunner(workerID string, close chan struct{},
 			select {
 			case <-close:
 				return // higher priority close in case both channels were available
-			default:
-				// Worker is now busy.
-				orch.metrics.RecordRunWorkerStats(atomic.AddInt32(&(orch.busyEventWorkers), 1), int32(orch.config.NumRunWorkers))
-
-				t0 := time.Now()
-				err := orch.performer.RunEvent(runnableEvent)
-				duration := time.Since(t0)
-
-				if err != nil {
-					orch.logger.Errorf("runEvents: %s could not run event %v after %v; err=%v", workerID, runnableEvent, duration, err)
-					orch.metrics.RecordRunEvent(false, duration, runnableEvent.URL, "error")
-				} else {
-					if duration > time.Second*30 {
-						orch.logger.Warningf("runEvents: %s ran job %v for a long time (%v)", workerID, runnableEvent, duration)
-					} else {
-						orch.logger.Debugf("runEvents: %s finished job %v after %v", workerID, runnableEvent, duration)
-					}
-					orch.metrics.RecordRunEvent(true, duration, runnableEvent.URL, "ok")
-				}
-
-				// Worker is back to idle.
-				orch.metrics.RecordRunWorkerStats(atomic.AddInt32(&(orch.busyEventWorkers), -1), int32(orch.config.NumRunWorkers))
+			default: // noop
 			}
+
+			var lock locker.Lock
+			var err error
+			if orch.locker != nil {
+				if lock, err = orch.locker.Lock(runnableEvent.Hash()); err != nil {
+					orch.logger.Warningf("error locking event %v: %v", runnableEvent, err)
+				}
+			}
+			// Worker is now busy.
+			orch.metrics.RecordRunWorkerStats(atomic.AddInt32(&(orch.busyEventWorkers), 1), int32(orch.config.NumRunWorkers))
+
+			t0 := time.Now()
+			err = orch.performer.RunEvent(runnableEvent)
+			duration := time.Since(t0)
+
+			if lock != nil {
+				lock.Unlock()
+			}
+
+			if err != nil {
+				orch.logger.Errorf("runEvents: %s could not run event %v after %v; err=%v", workerID, runnableEvent, duration, err)
+				orch.metrics.RecordRunEvent(false, duration, runnableEvent.URL, "error")
+			} else {
+				if duration > time.Second*30 {
+					orch.logger.Warningf("runEvents: %s ran job %v for a long time (%v)", workerID, runnableEvent, duration)
+				} else {
+					orch.logger.Debugf("runEvents: %s finished job %v after %v", workerID, runnableEvent, duration)
+				}
+				orch.metrics.RecordRunEvent(true, duration, runnableEvent.URL, "ok")
+			}
+
+			// Worker is back to idle.
+			orch.metrics.RecordRunWorkerStats(atomic.AddInt32(&(orch.busyEventWorkers), -1), int32(orch.config.NumRunWorkers))
 		}
 	}
 }

--- a/performer/mock.go
+++ b/performer/mock.go
@@ -6,9 +6,10 @@ import (
 )
 
 var _ Performer = &Mock{}
+
 // Mock is a fake performer, gives example data back. Useful for testing orchestrator changes.
 type Mock struct {
-	rotation int
+	rotation    int
 	UseSleeps   bool
 	LogCommands bool
 	RotateSites bool

--- a/performer/performer.go
+++ b/performer/performer.go
@@ -1,6 +1,8 @@
 package performer
 
 import (
+	"crypto/sha1"
+	"encoding/base32"
 	"fmt"
 	"time"
 )
@@ -24,6 +26,11 @@ type Event struct {
 
 func (e Event) String() string {
 	return fmt.Sprintf("event(url=%q, ts=%d, action=%q, instance=%q)", e.URL, e.Timestamp, e.Action, e.Instance)
+}
+
+func (e Event) Hash() string {
+	hs := sha1.Sum([]byte(e.String()))
+	return base32.StdEncoding.EncodeToString(hs[:])
 }
 
 // A Site in a WP install.

--- a/performer/performer.go
+++ b/performer/performer.go
@@ -28,7 +28,7 @@ func (e Event) String() string {
 	return fmt.Sprintf("event(url=%q, ts=%d, action=%q, instance=%q)", e.URL, e.Timestamp, e.Action, e.Instance)
 }
 
-func (e Event) Hash() string {
+func (e Event) LockKey() string {
 	hs := sha1.Sum([]byte(e.String()))
 	return base32.StdEncoding.EncodeToString(hs[:])
 }

--- a/performer/performer_test.go
+++ b/performer/performer_test.go
@@ -1,0 +1,41 @@
+package performer
+
+import "testing"
+
+func TestEvent_Hash(t *testing.T) {
+	type fields struct {
+		URL       string
+		Timestamp int
+		Action    string
+		Instance  string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+	}{
+		{
+			name: "hello",
+			fields: fields{
+				URL:       "https://foo.bar",
+				Timestamp: 12345,
+				Action:    "yolo",
+				Instance:  "daddy",
+			},
+			want: "WQQ5XKF6R4C6VWN3WYKFJQFGLMHDFBC2",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := Event{
+				URL:       tt.fields.URL,
+				Timestamp: tt.fields.Timestamp,
+				Action:    tt.fields.Action,
+				Instance:  tt.fields.Instance,
+			}
+			if got := e.Hash(); got != tt.want {
+				t.Errorf("Hash() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/performer/performer_test.go
+++ b/performer/performer_test.go
@@ -2,7 +2,7 @@ package performer
 
 import "testing"
 
-func TestEvent_Hash(t *testing.T) {
+func TestEvent_LockKey(t *testing.T) {
 	type fields struct {
 		URL       string
 		Timestamp int
@@ -33,8 +33,8 @@ func TestEvent_Hash(t *testing.T) {
 				Action:    tt.fields.Action,
 				Instance:  tt.fields.Instance,
 			}
-			if got := e.Hash(); got != tt.want {
-				t.Errorf("Hash() = %v, want %v", got, tt.want)
+			if got := e.LockKey(); got != tt.want {
+				t.Errorf("LockKey() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
this is an option if we dont want to do it in php :)

If locking is enabled, we read the list of cache servers from the wpvip "data config" file, which looks like:

```json
{
  "memcache": [
    {
      "host": "127.0.0.1",
      "port": 11211
    },
    // ...
  ]
}
```

We reload this file every `locker-refresh-interval` (default `10s`) to track changes to cache servers in near-realtime.

We hash the event (action + instance + ts + url) and use this as the cache key to lock.

Locks expire after `locker-lease-interval` (default `30s`), and are extended at half that time until unlocked (`15s` in the default case). So if a pod dies, the items it was running will unlock after 30s.

If cache is unavailable, locks are assumed to be granted, so this won't break crons but might allow duplicates. The only case where this changes the actual runner logic is if a lock was "successfully" conflicting.
