### PR TITLE
Add event age metrics

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -12,4 +12,5 @@ type Manager interface {
 	RecordLockEvent(status string)
 	RecordRunWorkerStats(currBusy int32, max int32)
 	RecordFpmTiming(isSuccess bool, elapsed time.Duration)
+	RecordSiteEventLag(url string, oldestEventTs time.Time)
 }

--- a/metrics/mock.go
+++ b/metrics/mock.go
@@ -5,9 +5,16 @@ import (
 	"time"
 )
 
+var _ Manager = Mock{}
 // Mock is a mock implementation of a Metrics Manager.
 type Mock struct {
 	Log bool
+}
+
+func (m Mock) RecordSiteEventLag(url string, oldestEventTs time.Time) {
+	if m.Log {
+		log.Printf("metrics: RecordSiteEventLag(url: %s, oldestEventTs: %v)", url, oldestEventTs)
+	}
 }
 
 func (m Mock) RecordLockEvent(status string) {

--- a/performer/mock.go
+++ b/performer/mock.go
@@ -2,6 +2,7 @@ package performer
 
 import (
 	"log"
+	"math/rand"
 	"time"
 )
 
@@ -71,11 +72,11 @@ func (perf *Mock) GetEvents(site Site) ([]Event, error) {
 	}
 
 	return []Event{
-		{Action: "action1", URL: site.URL},
-		{Action: "action2", URL: site.URL},
-		{Action: "action3", URL: site.URL},
-		{Action: "action4", URL: site.URL},
-		{Action: "action5", URL: site.URL},
+		{Action: "action1", URL: site.URL, Timestamp: int(time.Now().Unix() - rand.Int63n(12))},
+		{Action: "action2", URL: site.URL, Timestamp: int(time.Now().Unix() - rand.Int63n(12))},
+		{Action: "action3", URL: site.URL, Timestamp: int(time.Now().Unix() - rand.Int63n(12))},
+		{Action: "action4", URL: site.URL, Timestamp: int(time.Now().Unix() - rand.Int63n(12))},
+		{Action: "action5", URL: site.URL, Timestamp: int(time.Now().Unix() - rand.Int63n(12))},
 	}, nil
 }
 

--- a/performer/performer.go
+++ b/performer/performer.go
@@ -33,6 +33,10 @@ func (e Event) LockKey() string {
 	return base32.StdEncoding.EncodeToString(hs[:])
 }
 
+func (e Event) Time() time.Time {
+	return time.Unix(int64(e.Timestamp), 0)
+}
+
 // A Site in a WP install.
 type Site struct {
 	URL string `json:"url"`


### PR DESCRIPTION
This adds metrics that allow us to determine how far behind the cron runner is on a per-site basis.

```
% curl -fSsL localhost:9099/metrics | grep oldest
# HELP cron_control_runner_get_site_events_oldest_event_age_ms Age in milliseconds of the oldest event received in the last batch for this site
# TYPE cron_control_runner_get_site_events_oldest_event_age_ms gauge
cron_control_runner_get_site_events_oldest_event_age_ms{site_url="example4.com"} 10800
cron_control_runner_get_site_events_oldest_event_age_ms{site_url="example5.com"} 10407
cron_control_runner_get_site_events_oldest_event_age_ms{site_url="example6.com"} 11533
cron_control_runner_get_site_events_oldest_event_age_ms{site_url="example7.com"} 15534
cron_control_runner_get_site_events_oldest_event_age_ms{site_url="example8.com"} 9137
# HELP cron_control_runner_get_site_events_oldest_event_timestamp Timestamp of the oldest event received in the last batch for this site
# TYPE cron_control_runner_get_site_events_oldest_event_timestamp gauge
cron_control_runner_get_site_events_oldest_event_timestamp{site_url="example4.com"} 1.637333933e+09
cron_control_runner_get_site_events_oldest_event_timestamp{site_url="example5.com"} 1.63733391e+09
cron_control_runner_get_site_events_oldest_event_timestamp{site_url="example6.com"} 1.637333926e+09
cron_control_runner_get_site_events_oldest_event_timestamp{site_url="example7.com"} 1.637333927e+09
cron_control_runner_get_site_events_oldest_event_timestamp{site_url="example8.com"} 1.637333945e+09
```