### PR TITLE
GetEvents work distribution via locking

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.1 // indirect
 	github.com/golang/protobuf v1.4.3 // indirect
+	github.com/lthibault/jitterbug/v2 v2.2.2 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.26.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -60,6 +60,10 @@ github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFB
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/lthibault/jitterbug v2.0.0+incompatible h1:qouq51IKzlMx25+15jbxhC/d79YyTj0q6XFoptNqaUw=
+github.com/lthibault/jitterbug v2.0.0+incompatible/go.mod h1:2l7akWd27PScEs6YkjyUVj/8hKgNhbbQ3KiJgJtlf6o=
+github.com/lthibault/jitterbug/v2 v2.2.2 h1:v4+0tqryaI/TlYzgYE0Vhz7ha6Jtz4yRjmBP+PcqWPQ=
+github.com/lthibault/jitterbug/v2 v2.2.2/go.mod h1:evaHKX+60nFbFnEvGNPybQMJ5vXay9auziApDGo47Sw=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/locker/locker.go
+++ b/locker/locker.go
@@ -5,9 +5,16 @@ import (
 	"time"
 )
 
+type LockGroup string
+
+const (
+	GroupRunEvent  LockGroup = "run_event"
+	GroupGetEvents LockGroup = "get_events"
+)
+
 type Locker interface {
 	io.Closer
-	Lock(string, time.Duration) (Lock, error)
+	Lock(LockGroup, string, time.Duration) (Lock, error)
 }
 
 type Lock interface {

--- a/locker/locker.go
+++ b/locker/locker.go
@@ -2,11 +2,12 @@ package locker
 
 import (
 	"io"
+	"time"
 )
 
 type Locker interface {
 	io.Closer
-	Lock(string) (Lock, error)
+	Lock(string, time.Duration) (Lock, error)
 }
 
 type Lock interface {

--- a/locker/memcache.go
+++ b/locker/memcache.go
@@ -56,8 +56,15 @@ type memcacheLock struct {
 	Expires time.Time
 }
 
-func (m *memcacheLocker) Lock(k string, ttl time.Duration) (Lock, error) {
-	key := fmt.Sprintf("%s%s", m.KeyPrefix, k)
+func (m *memcacheLocker) cacheKey(g LockGroup, k string) string {
+	if m.KeyPrefix != "" {
+		return fmt.Sprintf("%s:%s:%s", m.KeyPrefix, string(g), k)
+	}
+	return fmt.Sprintf("%s:%s", string(g), k)
+}
+
+func (m *memcacheLocker) Lock(g LockGroup, k string, ttl time.Duration) (Lock, error) {
+	key := m.cacheKey(g, k)
 	ttl = ttl.Truncate(time.Second)
 	if ttl < time.Second {
 		ttl = time.Second

--- a/main.go
+++ b/main.go
@@ -65,7 +65,7 @@ func main() {
 	// Setup the locker, if any:
 	var lock locker.Locker
 	if options.useLocker {
-		lock = locker.NewMemcache(logger, "__ccr:lock:", options.dataConfigPath, 2*options.orchestratorConfig.GetEventsInterval, options.lockerRefreshInterval)
+		lock = locker.NewMemcache(logger, "__ccr:lock:", options.dataConfigPath, options.lockerRefreshInterval)
 		defer lock.Close()
 	}
 

--- a/main.go
+++ b/main.go
@@ -65,7 +65,7 @@ func main() {
 	// Setup the locker, if any:
 	var lock locker.Locker
 	if options.useLocker {
-		lock = locker.NewMemcache(logger, "__ccr:lock:", options.dataConfigPath, options.lockerRefreshInterval)
+		lock = locker.NewMemcache(logger, "__ccr", options.dataConfigPath, options.lockerRefreshInterval)
 		defer lock.Close()
 	}
 

--- a/main.go
+++ b/main.go
@@ -2,12 +2,6 @@ package main
 
 import (
 	"flag"
-	"github.com/Automattic/cron-control-runner/locker"
-	"github.com/Automattic/cron-control-runner/logger"
-	"github.com/Automattic/cron-control-runner/metrics"
-	"github.com/Automattic/cron-control-runner/orchestrator"
-	"github.com/Automattic/cron-control-runner/performer"
-	"github.com/Automattic/cron-control-runner/remote"
 	"log"
 	"math/rand"
 	"os"
@@ -15,6 +9,13 @@ import (
 	"path/filepath"
 	"syscall"
 	"time"
+
+	"github.com/Automattic/cron-control-runner/locker"
+	"github.com/Automattic/cron-control-runner/logger"
+	"github.com/Automattic/cron-control-runner/metrics"
+	"github.com/Automattic/cron-control-runner/orchestrator"
+	"github.com/Automattic/cron-control-runner/performer"
+	"github.com/Automattic/cron-control-runner/remote"
 )
 
 type options struct {
@@ -62,7 +63,7 @@ func main() {
 		perf = performer.NewCLI(options.wpCLIPath, options.wpPath, options.fpmURL, metricsManager, logger)
 	}
 
-	// Setup the locker, if any:
+	// Setup the locker, if enabled.
 	var lock locker.Locker
 	if options.useLocker {
 		lock = locker.NewMemcache(logger, "__ccr", options.dataConfigPath, options.lockerRefreshInterval)

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -1,8 +1,9 @@
 package metrics
 
 import (
-	"github.com/Automattic/cron-control-runner/locker"
 	"time"
+
+	"github.com/Automattic/cron-control-runner/locker"
 )
 
 // Manager is the contract that metric implementations must follow.

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -9,7 +9,7 @@ type Manager interface {
 	RecordGetSites(isSuccess bool, elapsed time.Duration)
 	RecordGetSiteEvents(isSuccess bool, elapsed time.Duration, siteURL string, numEvents int)
 	RecordRunEvent(isSuccess bool, elapsed time.Duration, siteURL string, reason string)
-	RecordLockEvent(status string)
+	RecordLockEvent(group, status string)
 	RecordRunWorkerStats(currBusy int32, max int32)
 	RecordFpmTiming(isSuccess bool, elapsed time.Duration)
 	RecordSiteEventLag(url string, oldestEventTs time.Time)

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"github.com/Automattic/cron-control-runner/locker"
 	"time"
 )
 
@@ -9,7 +10,7 @@ type Manager interface {
 	RecordGetSites(isSuccess bool, elapsed time.Duration)
 	RecordGetSiteEvents(isSuccess bool, elapsed time.Duration, siteURL string, numEvents int)
 	RecordRunEvent(isSuccess bool, elapsed time.Duration, siteURL string, reason string)
-	RecordLockEvent(group, status string)
+	RecordLockEvent(group locker.LockGroup, status string)
 	RecordRunWorkerStats(currBusy int32, max int32)
 	RecordFpmTiming(isSuccess bool, elapsed time.Duration)
 	RecordSiteEventLag(url string, oldestEventTs time.Time)

--- a/metrics/mock.go
+++ b/metrics/mock.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"github.com/Automattic/cron-control-runner/locker"
 	"log"
 	"time"
 )
@@ -18,7 +19,7 @@ func (m Mock) RecordSiteEventLag(url string, oldestEventTs time.Time) {
 	}
 }
 
-func (m Mock) RecordLockEvent(group, status string) {
+func (m Mock) RecordLockEvent(group locker.LockGroup, status string) {
 	if m.Log {
 		log.Printf("metrics: RecordLockEvent(group: %s, status: %s)", group, status)
 	}

--- a/metrics/mock.go
+++ b/metrics/mock.go
@@ -17,9 +17,9 @@ func (m Mock) RecordSiteEventLag(url string, oldestEventTs time.Time) {
 	}
 }
 
-func (m Mock) RecordLockEvent(status string) {
+func (m Mock) RecordLockEvent(group, status string) {
 	if m.Log {
-		log.Printf("metrics: RecordLockEvent(status: %s)", status)
+		log.Printf("metrics: RecordLockEvent(group: %s, status: %s)", group, status)
 	}
 }
 

--- a/metrics/mock.go
+++ b/metrics/mock.go
@@ -1,9 +1,10 @@
 package metrics
 
 import (
-	"github.com/Automattic/cron-control-runner/locker"
 	"log"
 	"time"
+
+	"github.com/Automattic/cron-control-runner/locker"
 )
 
 var _ Manager = Mock{}

--- a/metrics/mock.go
+++ b/metrics/mock.go
@@ -6,6 +6,7 @@ import (
 )
 
 var _ Manager = Mock{}
+
 // Mock is a mock implementation of a Metrics Manager.
 type Mock struct {
 	Log bool

--- a/metrics/prom.go
+++ b/metrics/prom.go
@@ -1,10 +1,11 @@
 package metrics
 
 import (
-	"github.com/Automattic/cron-control-runner/locker"
 	"log"
 	"net/http"
 	"time"
+
+	"github.com/Automattic/cron-control-runner/locker"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"

--- a/metrics/prom.go
+++ b/metrics/prom.go
@@ -74,8 +74,9 @@ func (p *Prom) RecordRunEvent(isSuccess bool, elapsed time.Duration, siteURL str
 	})).Observe(elapsed.Seconds())
 }
 
-func (p *Prom) RecordLockEvent(status string) {
+func (p *Prom) RecordLockEvent(group, status string) {
 	p.ctrLockerEventsTotal.With(prometheus.Labels{
+		"group": group,
 		"status": status,
 	}).Inc()
 }
@@ -173,7 +174,7 @@ func (p *Prom) initializeMetrics() {
 		Subsystem: "locker",
 		Name:      "events_total",
 		Help:      "Number of events locked",
-	}, []string{"status"})
+	}, []string{"group", "status"})
 
 	p.histWpcliStatMaxRSS = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: metricNamespace,

--- a/metrics/prom.go
+++ b/metrics/prom.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"github.com/Automattic/cron-control-runner/locker"
 	"log"
 	"net/http"
 	"time"
@@ -74,9 +75,9 @@ func (p *Prom) RecordRunEvent(isSuccess bool, elapsed time.Duration, siteURL str
 	})).Observe(elapsed.Seconds())
 }
 
-func (p *Prom) RecordLockEvent(group, status string) {
+func (p *Prom) RecordLockEvent(group locker.LockGroup, status string) {
 	p.ctrLockerEventsTotal.With(prometheus.Labels{
-		"group":  group,
+		"group":  string(group),
 		"status": status,
 	}).Inc()
 }

--- a/metrics/prom.go
+++ b/metrics/prom.go
@@ -76,7 +76,7 @@ func (p *Prom) RecordRunEvent(isSuccess bool, elapsed time.Duration, siteURL str
 
 func (p *Prom) RecordLockEvent(group, status string) {
 	p.ctrLockerEventsTotal.With(prometheus.Labels{
-		"group": group,
+		"group":  group,
 		"status": status,
 	}).Inc()
 }

--- a/orchestrator/orchestrator.go
+++ b/orchestrator/orchestrator.go
@@ -246,6 +246,9 @@ func (orch *Orchestrator) setupRunners() error {
 	return nil
 }
 
+const LockGroupRunEvent = "run-event"
+const LockGroupGetEvents = "get-events"
+
 func (orch *Orchestrator) startEventRunner(workerID string, close chan struct{}, wg *sync.WaitGroup) {
 	defer wg.Done()
 	defer orch.logger.Infof("shutdown %q gracefully", workerID)
@@ -267,14 +270,14 @@ func (orch *Orchestrator) startEventRunner(workerID string, close chan struct{},
 				if lock, err = orch.locker.Lock(runnableEvent.LockKey()); err != nil {
 					// if there is an error, we continue as if it is not locked:
 					orch.logger.Warningf("error locking event %v: %v", runnableEvent, err)
-					orch.metrics.RecordLockEvent("error")
+					orch.metrics.RecordLockEvent(LockGroupRunEvent, "error")
 				} else if lock == nil {
 					// already locked, move on:
-					orch.metrics.RecordLockEvent("already_locked")
+					orch.metrics.RecordLockEvent(LockGroupRunEvent, "already_locked")
 					continue
 				} else {
 					// we got a lock:
-					orch.metrics.RecordLockEvent("locked")
+					orch.metrics.RecordLockEvent(LockGroupRunEvent, "locked")
 				}
 			}
 

--- a/orchestrator/orchestrator.go
+++ b/orchestrator/orchestrator.go
@@ -200,10 +200,8 @@ func (orch *Orchestrator) fetchSiteEvents(site site, close chan struct{}) {
 		<-orch.semGetEvents
 	})()
 
-	var lock locker.Lock
 	if orch.locker != nil {
-		var err error
-		if lock, err = orch.locker.Lock(site.LockKey(), orch.config.GetEventsInterval); err != nil {
+		if lock, err := orch.locker.Lock(site.LockKey(), orch.config.GetEventsInterval); err != nil {
 			// if there is an error, we continue as if it is not locked:
 			orch.logger.Warningf("error locking site %s: %v", site.URL, err)
 			orch.metrics.RecordLockEvent(LockGroupGetEvents, "error")

--- a/performer/performer.go
+++ b/performer/performer.go
@@ -47,5 +47,5 @@ type Sites = map[string]Site
 
 func (s *Site) LockKey() string {
 	hs := sha1.Sum([]byte(s.URL))
-	return "site:" + base32.StdEncoding.EncodeToString(hs[:])
+	return base32.StdEncoding.EncodeToString(hs[:])
 }

--- a/performer/performer.go
+++ b/performer/performer.go
@@ -44,3 +44,8 @@ type Site struct {
 
 // Sites is a map of siteurl => Site
 type Sites = map[string]Site
+
+func (s *Site) LockKey() string {
+	hs := sha1.Sum([]byte(s.URL))
+	return "site:" + base32.StdEncoding.EncodeToString(hs[:])
+}


### PR DESCRIPTION
This PR adds locking around the getEvents invocations for each site. Currently, for large multisites, every runner polls every site every interval, which adds quite a bit of overhead, and reduces the effective average interval at which site is polled to `get-events-interval / N` where _N_ is the number of runners (pods). For extremely large multisites (hundreds, thousands of sites) this is so much CPU that runners will be scaled up to the max.

By locking the site for the `get-events-interval`, we ensure no other runner will even attempt to get the events until the TTL expires.

However, we also introduce some jitter to the get-events ticker in each site watcher. This is to prevent one runner from dominating all sites with a TTL that lines up perfectly with its next interval, and therefore making scaling less useful. This jitter means that the actual interval will float slightly around the `get-events-interval` and either:
a) The interval will be slightly shorter than the lock, the same runner will fail to obtain the lock and skip an iteration, giving other runners a chance to take it instead, or 
b) The interval will be slightly longer than the lock, which gives a small window for another runner to take it.

In testing, this converges to an ideal work distribution within just a couple seconds.
