### PR TITLE
Remote runner: Avoid panic by erroring checking first

### DIFF
--- a/remote/remote.go
+++ b/remote/remote.go
@@ -804,15 +804,16 @@ func runWpCliCmdRemote(conn net.Conn, GUID string, rows uint16, cols uint16, wpC
 				// This is because the command has been terminated
 				break
 			}
-			read, err = tty.Read(buf)
-			atomic.AddInt64(&wpcli.BytesLogged, int64(read))
 
+			read, err = tty.Read(buf)
 			if nil != err {
 				if io.EOF != err {
 					log.Printf("error reading WP CLI tty output: %s\n", err.Error())
 				}
 				break
 			}
+
+			atomic.AddInt64(&wpcli.BytesLogged, int64(read))
 
 			if 0 == read {
 				continue


### PR DESCRIPTION
Have not really tested, but this looks like a general concurrency / race condition type of thing (another go routine closes the connection right as this routine is just starting a new loop). And the PR is pretty straightforward code-wise I think.

What we're seeing in logs:

```
14:58:43 launching fcd112c3e-9da5-4f31-a2ds-70ad3b149085 - rows: 51, cols: 163, args: example cli
14:58:43 handshake complete!
14:58:43 Creating the logfile /tmp/wp-cli-fcd112c3e-9da5-4f31-a2ds-70ad3b149085

15:02:24 client connection closed
15:02:24 closing watcher and read file
15:02:24 WP CLI command finished and all data has been written, exiting this watcher loop

15:02:29 error reading WP CLI tty output: read /dev/ptmx: input/output error
15:02:29 closing logfile and marking the WP-CLI as finished
15:02:29 cleaning out fcd112c3e-9da5-4f31-a2ds-70ad3b149085

15:02:30 panic: runtime error: invalid memory address or nil pointer dereference: /remote/remote.go:797, sync.(*Mutex).Lock(...), [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x7bfbea]
```