### PR TITLE
Validate only JSON Objects in remote.go commands

### DIFF
--- a/remote/remote.go
+++ b/remote/remote.go
@@ -959,5 +959,9 @@ func isJSON(str string) bool {
 }
 
 func isJSONObject(str string) bool {
-	return -1 != strings.Index(str, "{") && isJSON(str)
+	trimmedStr := strings.TrimSpace(str)
+	if !strings.HasPrefix(trimmedStr, "{") || !strings.HasSuffix(trimmedStr, "}") {
+		return false
+	}
+	return isJSON(str)
 }

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -391,7 +391,7 @@ func getCleanWpCliArgumentArray(wpCliCmdString string) ([]string, error) {
 
 	// Remove quotes from the args
 	for i := range cleanArgs {
-		if( ! isJSON( cleanArgs[i])) { //don't alter JSON arguments
+		if !isJSON(cleanArgs[i]) { //don't alter JSON arguments
 			cleanArgs[i] = strings.ReplaceAll(cleanArgs[i], "\"", "")
 		}
 	}
@@ -650,7 +650,9 @@ func runWpCliCmdRemote(conn net.Conn, GUID string, rows uint16, cols uint16, wpC
 	cmdArgs := make([]string, 0)
 	cmdArgs = append(cmdArgs, strings.Fields("--path="+remoteConfig.wpPath)...)
 
+	log.Printf("string %s\n", wpCliCmdString)
 	cleanArgs, err := getCleanWpCliArgumentArray(wpCliCmdString)
+	log.Printf("string2 %s\n", strings.Join(cleanArgs, " "))
 	if nil != err {
 		conn.Write([]byte("WP CLI command is invalid"))
 		conn.Close()
@@ -955,4 +957,8 @@ func tokenizeString(rawString string) []string {
 func isJSON(str string) bool {
 	var js json.RawMessage
 	return json.Unmarshal([]byte(str), &js) == nil
+}
+
+func isJSONObject(str string) bool {
+	return -1 != strings.Index(str, "{") && isJSON(str)
 }

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -955,8 +955,7 @@ func tokenizeString(rawString string) []string {
 }
 
 func isJSON(str string) bool {
-	var js json.RawMessage
-	return json.Unmarshal([]byte(str), &js) == nil
+	return json.Valid([]byte(str))
 }
 
 func isJSONObject(str string) bool {

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -391,7 +391,7 @@ func getCleanWpCliArgumentArray(wpCliCmdString string) ([]string, error) {
 
 	// Remove quotes from the args
 	for i := range cleanArgs {
-		if !isJSON(cleanArgs[i]) { //don't alter JSON arguments
+		if !isJSONObject(cleanArgs[i]) { //don't alter JSON arguments
 			cleanArgs[i] = strings.ReplaceAll(cleanArgs[i], "\"", "")
 		}
 	}

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -656,6 +656,7 @@ func runWpCliCmdRemote(conn net.Conn, GUID string, rows uint16, cols uint16, wpC
 		conn.Close()
 		return errors.New(err.Error())
 	}
+	log.Printf("LOG CLI Arguments (%d elements): %s", len(cleanArgs), strings.Join(cleanArgs, ", "))
 
 	cmdArgs = append(cmdArgs, cleanArgs...)
 

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -650,9 +650,7 @@ func runWpCliCmdRemote(conn net.Conn, GUID string, rows uint16, cols uint16, wpC
 	cmdArgs := make([]string, 0)
 	cmdArgs = append(cmdArgs, strings.Fields("--path="+remoteConfig.wpPath)...)
 
-	log.Printf("string %s\n", wpCliCmdString)
 	cleanArgs, err := getCleanWpCliArgumentArray(wpCliCmdString)
-	log.Printf("string2 %s\n", strings.Join(cleanArgs, " "))
 	if nil != err {
 		conn.Write([]byte("WP CLI command is invalid"))
 		conn.Close()

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -1,22 +1,32 @@
 package remote
 
 import (
+	"reflect"
 	"testing"
 )
 
 func TestCheckIsJSONObject(t *testing.T) {
-	valuesToTestFalse := []string{
-		"\"Valid JSON String that should be excluded\"",
-		"wrong json string"}
-	valuesToTestTrue := []string{"{\"correct\":\"json object\"}", " { \"correct\" : \"json object with extra spacing\" } "}
-	for _, val := range valuesToTestFalse {
-		if isJSONObject(val) {
-			t.Fatalf("isJSONObject() returned true for %s while it should've been false", val)
-		}
+	tests := map[string]struct {
+		input string
+		want  bool
+	}{
+		"normal text with no quotes":                {want: false, input: "normal text"},
+		"array object":                              {want: false, input: "[1,2,3]"},
+		"valid json string that should be excluded": {want: false, input: `"normal text inside quotes"`},
+		"missing quotes json":                       {want: false, input: `{"broken":json"}`},
+		"json inside extra quotes":                  {want: false, input: `"{"broken":"json"}"`},
+		"missing closing parenthesis":               {want: false, input: `{"broken":"json object"`},
+		"wrong numerical key json":                  {want: false, input: ` { 1 : " wrong" } `},
+		"standard json":                             {want: true, input: `{"object":"json"}`},
+		"json with extra spacing":                   {want: true, input: `  { "object space" : "with spacing" } `},
 	}
-	for _, val := range valuesToTestTrue {
-		if !isJSONObject(val) {
-			t.Fatalf("isJSONObject() returned false for %s while it should've been true", val)
-		}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := isJSONObject(tc.input)
+			if !reflect.DeepEqual(tc.want, got) {
+				t.Fatalf("testing '%v' isJSONObject(\"%v\") expected: %v, got: %v", name, tc.input, tc.want, got)
+			}
+		})
 	}
 }

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -7,17 +7,16 @@ import (
 func TestCheckIsJSONObject(t *testing.T) {
 	valuesToTestFalse := []string{
 		"\"Valid JSON String that should be excluded\"",
-		"wrong json string",
-		"\"{\\\"correct\\\":\\\"json object with \\\"}\""}
+		"wrong json string"}
 	valuesToTestTrue := []string{"{\"correct\":\"json object\"}", " { \"correct\" : \"json object with extra spacing\" } "}
 	for _, val := range valuesToTestFalse {
 		if isJSONObject(val) {
-			t.Fatalf("isJSON() returned true for %s while it should've been false", val)
+			t.Fatalf("isJSONObject() returned true for %s while it should've been false", val)
 		}
 	}
 	for _, val := range valuesToTestTrue {
 		if !isJSONObject(val) {
-			t.Fatalf("isJSON() returned false for %s while it should've been false", val)
+			t.Fatalf("isJSONObject() returned false for %s while it should've been true", val)
 		}
 	}
 }

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -1,0 +1,23 @@
+package remote
+
+import (
+	"testing"
+)
+
+func TestCheckIsJSONObject(t *testing.T) {
+	valuesToTestFalse := []string{
+		"\"Valid JSON String that should be excluded\"",
+		"wrong json string",
+		"\"{\\\"correct\\\":\\\"json object with \\\"}\""}
+	valuesToTestTrue := []string{"{\"correct\":\"json object\"}", " { \"correct\" : \"json object with extra spacing\" } "}
+	for _, val := range valuesToTestFalse {
+		if isJSONObject(val) {
+			t.Fatalf("isJSON() returned true for %s while it should've been false", val)
+		}
+	}
+	for _, val := range valuesToTestTrue {
+		if !isJSONObject(val) {
+			t.Fatalf("isJSON() returned false for %s while it should've been false", val)
+		}
+	}
+}


### PR DESCRIPTION
### Description

This change aims to fix a bug with commands like these
` vip @site.env --yes -- wp search-replace "Some Space" "Some Space Test" --all-tables --report-changed-only --dry-run`
That don't work because right now `"Ways At"` is a string containing double quotes and that is also a valid JSON (therefore the double quotes aren't removed and we are searching the wrong information.

The change will impact how we validate JSON (introduced in #9 ) by  validating it only if we presume we have a JSON Object to validate.

This is achieved by checking if the command string contain the `{` and the `}` as starting/ending characters (after trimming the spaces)