### PR TITLE
Added a check to avoid using the padlock if it has been nulled

### DIFF
--- a/remote/remote.go
+++ b/remote/remote.go
@@ -634,6 +634,7 @@ func attachWpCliCmdRemote(conn net.Conn, wpcli *wpCLIProcess, GUID string, rows 
 	delete(wpcli.BytesStreamed, remoteAddress)
 	if 0 == len(wpcli.BytesStreamed) {
 		log.Printf("cleaning out %s\n", GUID)
+		wpcli.Running = false
 		wpcli.padlock.Unlock()
 		wpcli.padlock = nil
 		padlock.Lock()
@@ -874,6 +875,10 @@ func runWpCliCmdRemote(conn net.Conn, GUID string, rows uint16, cols uint16, wpC
 
 	for {
 		if (!wpcli.Running && wpcli.BytesStreamed[remoteAddress] >= wpcli.BytesLogged) || nil == conn {
+			if nil == conn {
+				log.Println("WWWWAIT")
+				time.Sleep(time.Duration(200 * time.Millisecond.Nanoseconds()))
+			}
 			break
 		}
 		log.Printf("waiting for remaining bytes to be sent to a client: at %d - have %d\n", wpcli.BytesStreamed[remoteAddress], wpcli.BytesLogged)

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -838,10 +838,11 @@ func runWpCliCmdRemote(conn net.Conn, GUID string, rows uint16, cols uint16, wpC
 		logFile.Close()
 
 		time.Sleep(time.Duration(50 * time.Millisecond.Nanoseconds()))
-
-		wpcli.padlock.Lock()
-		wpcli.Running = false
-		wpcli.padlock.Unlock()
+		if wpcli.Running {
+			wpcli.padlock.Lock()
+			wpcli.Running = false
+			wpcli.padlock.Unlock()
+		}
 	}()
 
 	go func() {
@@ -886,6 +887,7 @@ func runWpCliCmdRemote(conn net.Conn, GUID string, rows uint16, cols uint16, wpC
 	delete(wpcli.BytesStreamed, remoteAddress)
 	if 0 == len(wpcli.BytesStreamed) {
 		log.Printf("cleaning out %s\n", GUID)
+		wpcli.Running = false
 		wpcli.padlock.Unlock()
 		wpcli.padlock = nil
 		padlock.Lock()

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -833,15 +833,18 @@ func runWpCliCmdRemote(conn net.Conn, GUID string, rows uint16, cols uint16, wpC
 				break
 			}
 		}
-		log.Println("closing logfile and marking the WP-CLI as finished")
+		log.Println("closing logfile")
 		logFile.Sync()
 		logFile.Close()
 
 		time.Sleep(time.Duration(50 * time.Millisecond.Nanoseconds()))
 		if wpcli.Running {
+			log.Println("marking the WP-CLI as finished")
 			wpcli.padlock.Lock()
 			wpcli.Running = false
 			wpcli.padlock.Unlock()
+		} else {
+			log.Println("WP-CLI already finished running")
 		}
 	}()
 

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -875,10 +875,6 @@ func runWpCliCmdRemote(conn net.Conn, GUID string, rows uint16, cols uint16, wpC
 
 	for {
 		if (!wpcli.Running && wpcli.BytesStreamed[remoteAddress] >= wpcli.BytesLogged) || nil == conn {
-			if nil == conn {
-				log.Println("WWWWAIT")
-				time.Sleep(time.Duration(200 * time.Millisecond.Nanoseconds()))
-			}
 			break
 		}
 		log.Printf("waiting for remaining bytes to be sent to a client: at %d - have %d\n", wpcli.BytesStreamed[remoteAddress], wpcli.BytesLogged)


### PR DESCRIPTION
## Description

This PR is subsequent to the #10. 
There is a concurrency issue in some rare cases where we get to execute the `wpcli.padlock.Lock()` when the padlock variable has already been nulled therefore resulting in a panic error.

To avoid this we put the Running state to false once we've reached the end of the execution, this allows the goroutine to skip the lock in case we've already finished.

To better understand the behavior in production the logs have been splitted so we know what route the program has taken. 