### PR TITLE
Do not finish the command on attachWpCliCmdRemote or on connection errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/bradfitz/gomemcache v0.0.0-20190913173617-a41fca850d0b
-	github.com/creack/pty v1.1.17
+	github.com/creack/pty v1.1.18
 	github.com/howeyc/fsnotify v0.9.0
 	github.com/prometheus/client_golang v1.11.0
 	github.com/yookoala/gofast v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/creack/pty v1.1.17 h1:QeVUsEDNrLBW4tMgZHvxy18sKtr6VI492kBhUfhDJNI=
 github.com/creack/pty v1.1.17/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
+github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
+github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -859,7 +859,7 @@ func runWpCliCmdRemote(conn net.Conn, GUID string, rows uint16, cols uint16, wpC
 		log.Printf("runWpCliCmdRemote: error from the wp command: %s\n", err.Error())
 	}
 
-	log.Printf("runWpCliCmdRemote: comand finished")
+	log.Printf("runWpCliCmdRemote: comand finished: %s\n", GUID)
 
 	if wpcli.Running {
 		log.Println("runWpCliCmdRemote: marking the WP-CLI as finished")

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -611,7 +611,7 @@ func attachWpCliCmdRemote(conn net.Conn, wpcli *wpCLIProcess, GUID string, rows 
 			select {
 			case <-ticker:
 				if !connectionActive {
-					log.Println("attachWpCliCmdRemote: client connection is closed, exiting this watcher loop")
+					log.Println("attachWpCliCmdRemote: ticker: client connection is closed, exiting this watcher loop")
 					break Watcher_Loop
 				}
 
@@ -630,6 +630,11 @@ func attachWpCliCmdRemote(conn net.Conn, wpcli *wpCLIProcess, GUID string, rows 
 				read, err = readFile.Read(buf)
 				if 0 == read {
 					continue
+				}
+
+				if !connectionActive || conn == nil {
+					log.Println("attachWpCliCmdRemote: client connection is closed, exiting this watcher loop")
+					break Watcher_Loop
 				}
 
 				written, err = conn.Write(buf[:read])


### PR DESCRIPTION
# Description

This PR addresses three different issues that could prevent long-running commands or commands with large outputs from executing successfully.

## Reconnect

The first time we run a command, the `runWpCliCmdRemote` function is executed (https://github.com/Automattic/cron-control-runner/blob/trunk/remote/remote.go#L650). If the client loses the connection, the command keeps running (https://github.com/Automattic/cron-control-runner/blob/trunk/remote/remote.go#L858).
When the client tries to reconnect, instead of reaching `runWpCliCmdRemote` it goes to `attachWpCliCmdRemote` (https://github.com/Automattic/cron-control-runner/blob/trunk/remote/remote.go#L481), which is responsible for keeping pushing the command output.
At this time, everything is ok. The command is still running and the client is receiving the output from `attachWpCliCmdRemote`.

The problem is when the client loses the connection again. Then `attachWpCliCmdRemote` marks the command as `running=false` (https://github.com/Automattic/cron-control-runner/blob/trunk/remote/remote.go#L637), so, on the next reconnect, instead of calling `attachWpCliCmdRemote` it will call runWpCliCmdRemote (https://github.com/Automattic/cron-control-runner/blob/trunk/remote/remote.go#L231), which will trigger the command again with the same GUID. We will end up having the same command being executed twice with the same GUID.

So, to fix it, we no longer mark the command as `running=false` on `attachWpCliCmdRemote`. 

## Finishing command on connection error

We are marking the command as `running=false` on every connection error. This doesn't allow us to reconnect/`attachWpCliCmdRemote` to the command.

To "fix" it, we only mark the command as `running=false` after `cmd.Process.Wait()`.

## CTRL+C null pointer

When the finished the command execution with CTRL+C, we try to write `Command has been terminated` back to the connection. If the connection is already finished, we get a null pointer error.

To fix it, before we write back to the connection, we check if we still have the connection. 
