### PR TITLE
Resume command that is already finished

### DIFF
--- a/remote/remote.go
+++ b/remote/remote.go
@@ -237,7 +237,7 @@ func authConn(conn net.Conn) {
 	wpCLIProcess, found := gGUIDttys[GUID]
 	padlock.Unlock()
 
-	if found && wpCLIProcess.Running {
+	if found {
 		if "vip-go-retrieve-remote-logs" == cmd {
 			conn.Write([]byte(fmt.Sprintf("Not sending the logs because the WP-CLI command with GUID %s is still running", GUID)))
 			conn.Close()


### PR DESCRIPTION
# Description

Currently, only running commands can be resumed. This PR removes this limitation since the *output* of non-running commands can also be resumed.

This is important for commands with significant outputs, where the output is quickly written to disk while it takes time to send it through WebSocket.