### PR TITLE
WP-CLI: docker-compose-based dev env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor/
 *~
-/bin/
+/bin/cron-control-runner
+.env

--- a/bin/docker-init.sh
+++ b/bin/docker-init.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+echo "Initializing."
+
+if [[ -z "$( which nc )" && -n "$( which apt-get )" ]]; then
+    apt-get update
+    apt-get install -y netcat
+fi
+
+while [[ true ]]; do
+    if nc -z db 3306; then
+        echo "db is up."
+        break;
+    fi;
+    echo "Waiting for db..."
+    sleep 1;
+done
+
+wp core install \
+    --url="http://wordpress" \
+    --title="cron-control-runner WordPress Tester" \
+    --admin_user="admin" \
+    --admin_email="example@example.com";
+
+/usr/local/bin/wp-cron-runner \
+    -debug=true \
+    -token=$WP_CLI_TOKEN \
+    -use-websockets=true \
+    -wp-cli-path=/usr/local/bin/wp \
+    -wp-path=/var/www/html

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,47 @@
+services:
+  db:
+    image: mariadb
+    volumes:
+      - db_data:/var/lib/mysql
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: Sup3rDup3rS3cur3
+      MYSQL_DATABASE: wordpress
+      MYSQL_USER: wordpress
+      MYSQL_PASSWORD: wordpress
+
+  # This container is helpful in that it provides the WP files & creates the wp-config.php for us from the env vars
+  wordpress:
+    depends_on:
+      - db
+    image: wordpress
+    environment:
+      WORDPRESS_DB_HOST: db:3306
+      WORDPRESS_DB_USER: wordpress
+      WORDPRESS_DB_PASSWORD: wordpress
+      WORDPRESS_DB_NAME: wordpress
+    volumes:
+      - wp_data:/var/www/html
+
+  wpcli:
+    image: "${BATCH_IMAGE_NAME:-wordpress:cli}"
+    depends_on:
+      - db
+      - wordpress
+    environment:
+      WORDPRESS_DB_HOST: db:3306
+      WORDPRESS_DB_USER: wordpress
+      WORDPRESS_DB_PASSWORD: wordpress
+      WORDPRESS_DB_NAME: wordpress
+      WP_CLI_TOKEN: ${WP_CLI_TOKEN}
+    entrypoint: /usr/local/bin/docker-init.sh
+    volumes:
+      - wp_data:/var/www/html
+      - ./bin/cron-control-runner:/usr/local/bin/wp-cron-runner
+      - ./bin/docker-init.sh:/usr/local/bin/docker-init.sh
+    ports:
+      - "22122:22122"
+
+volumes:
+  db_data:
+  wp_data:

--- a/readme.md
+++ b/readme.md
@@ -13,12 +13,27 @@ A Go-based runner for processing WordPress cron events, via [Cron Control](https
 cron-control-runner -debug -wp-path="/var/www/html" -wp-cli-path="/usr/local/bin/wp"
 ```
 
+### Development
+
 If you would just like to test the runner locally, can do a simpler process and even feed it mock data:
 
 ```
 cd path/to/cloned/repo/cron-control-runner
 go run . -use-mock-data -debug
 ```
+
+Another option for a more realistic test environment is provided via docker:
+
+1. Build the binary as usual (see [Installation & Usage](#installation--usage))
+    Make sure it's at the specified location (`bin/cron-control-runner` & built with the specified target params).
+1. `docker-compose up`
+
+This will spin up a clean WordPress instance and kick off an [intialization script](./bin/docker-init.sh) on the CLI container which culminates in cron-control-runner listening for connections on the host os at the usual port (`21222`).
+
+It's helpful to specify some environment variables (e.g. in an `.env` file):
+
+* You can specify the image for the cli container via the `BATCH_IMAGE_NAME` environment variable. By default, `wordpress:cli` is used.
+* You can specify the `remoteToken` value via the `WP_CLI_TOKEN` environment variable.
 
 ## Runner Options
 - `-debug`


### PR DESCRIPTION
This change makes it really easy to test remote WP-CLI commands locally by spinning up a fresh, containerized WordPress site & kicking off your freshly-built `cron-control-runner` binary.

## How to Test

Essentially, it's just:
* Build the binary w/ an appropriate command
* Set some env vars
* `docker-compose up`

Follow along with the included changes to the [documentation](https://github.com/Automattic/cron-control-runner/blob/try/dockerized-wp/readme.md#development). Take note of the environment variables. By default, this will run a core `wordpress:cli` container and not use a `WP_CLI_TOKEN`.

If there is additional information required to test this, please speak up and let's get it into the README.

Once this is running:
* Run the API locally with your wp-cli-socket address pointed at this service's address and port
* Run various commands with the CLI while it's pointed at your local API (e.g. `VIP_PROXY="" API_HOST="http://localhost:4000" vip wp @test1-go-vip.production option get blogname -y`)
