### PR TITLE
WP-CLI: Allow db query subcommand (with a param)

### DIFF
--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -30,3 +30,41 @@ func TestCheckIsJSONObject(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateCommand(t *testing.T) {
+	tests := map[string]struct {
+		errString string
+		input     string
+		want      string
+	}{
+		"config edit should fail":                    {errString: "WP CLI command 'config' is not permitted", want: "", input: "config edit"},
+		"db create should fail":                      {errString: "WP CLI command 'db create' is not permitted", want: "", input: "db create"},
+		"db export should fail":                      {errString: "WP CLI command 'db export' is not permitted", want: "", input: "db export somefile.sql"},
+		"db reset --yes should fail":                 {errString: "WP CLI command 'db reset' is not permitted", want: "", input: "db reset --yes"},
+		"db query without a query param should fail": {errString: "WP CLI command 'db query' requires a query parameter", want: "", input: "db query"},
+		"db query with a query param should pass":    {errString: "", want: "db query \"SELECT * FROM whatever\"", input: "db query \"SELECT * FROM whatever\""},
+		"db query with trailing spaces should fail":  {errString: "WP CLI command 'db query' requires a query parameter", want: "", input: "db query     "},
+		"media regenerate should fail":               {errString: "WP CLI command 'media regenerate' is not permitted", want: "", input: "media regenerate"},
+		"media import file should pass":              {errString: "", want: "media import https://example.com/cutekitties.png", input: "media import https://example.com/cutekitties.png"},
+		"vip support-user should fail":               {errString: "WP CLI command 'vip support-user' is not permitted", want: "", input: "vip support-user"},
+		"vip whatever shold pass":                    {errString: "", want: "vip whatever", input: "vip whatever"},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := validateCommand(tc.input)
+
+			if err != nil && tc.errString != err.Error() {
+				t.Fatalf("testing '%v' validateCommand(\"%v\") expected error: %v, got: %v", name, tc.input, tc.errString, err.Error())
+			}
+
+			if err == nil && tc.errString != "" {
+				t.Fatalf("testing '%v' validateCommand(\"%v\") expected error string: %v, got: nil", name, tc.input, tc.errString)
+			}
+
+			if tc.want != got {
+				t.Fatalf("testing '%v' validateCommand(\"%v\") expected: %v, got: %v", name, tc.input, tc.want, got)
+			}
+		})
+	}
+}

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -47,7 +47,7 @@ func TestValidateCommand(t *testing.T) {
 		"media regenerate should fail":               {errString: "WP CLI command 'media regenerate' is not permitted", want: "", input: "media regenerate"},
 		"media import file should pass":              {errString: "", want: "media import https://example.com/cutekitties.png", input: "media import https://example.com/cutekitties.png"},
 		"vip support-user should fail":               {errString: "WP CLI command 'vip support-user' is not permitted", want: "", input: "vip support-user"},
-		"vip whatever shold pass":                    {errString: "", want: "vip whatever", input: "vip whatever"},
+		"vip whatever should pass":                    {errString: "", want: "vip whatever", input: "vip whatever"},
 	}
 
 	for name, tc := range tests {

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -47,7 +47,7 @@ func TestValidateCommand(t *testing.T) {
 		"media regenerate should fail":               {errString: "WP CLI command 'media regenerate' is not permitted", want: "", input: "media regenerate"},
 		"media import file should pass":              {errString: "", want: "media import https://example.com/cutekitties.png", input: "media import https://example.com/cutekitties.png"},
 		"vip support-user should fail":               {errString: "WP CLI command 'vip support-user' is not permitted", want: "", input: "vip support-user"},
-		"vip whatever should pass":                    {errString: "", want: "vip whatever", input: "vip whatever"},
+		"vip whatever should pass":                   {errString: "", want: "vip whatever", input: "vip whatever"},
 	}
 
 	for name, tc := range tests {


### PR DESCRIPTION
This change permits cron-control-runner to run the `wp db query` command when a query parameter is included.

It also adds testing for the `validateCommand` function.

## To Test

### Automated Tests

`go test ./remote`

### Manual Tests

* Build & run following the instructions in the README
* Run the API locally with your wp-cli-socket address pointed at this service's address and port
* Run various commands with the CLI while it's pointed at your local API (e.g. `VIP_PROXY="" API_HOST="http://localhost:4000" vip wp @test1-go-vip.production db query "SHOW TABLES" -y`)
  * Confirm that appropriate commands are blocked and allowed.

Pulled out of #18
