### PR TITLE
feat: add support for tcp sockets for php-fpm

### DIFF
--- a/performer/cli.go
+++ b/performer/cli.go
@@ -3,8 +3,6 @@ package performer
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/Automattic/cron-control-runner/logger"
-	"github.com/Automattic/cron-control-runner/metrics"
 	"io"
 	"math/rand"
 	"net/http"
@@ -12,6 +10,9 @@ import (
 	"os/exec"
 	"strings"
 	"time"
+
+	"github.com/Automattic/cron-control-runner/logger"
+	"github.com/Automattic/cron-control-runner/metrics"
 
 	"github.com/yookoala/gofast"
 )
@@ -58,12 +59,17 @@ func NewCLI(wpCLIPath string, wpPath string, fpmURL string, metrics metrics.Mana
 	if fpmURL != "" {
 		var err error
 		parsedURL, err := url.Parse(fpmURL)
-		if err != nil || parsedURL == nil || parsedURL.Scheme != "unix" || parsedURL.Path == "" {
+		if err != nil || parsedURL == nil || (parsedURL.Scheme == "unix" && parsedURL.Path == "") || ((parsedURL.Scheme == "tcp" || parsedURL.Scheme == "tcp4" || parsedURL.Scheme == "tcp6") && parsedURL.Host == "") {
 			logger.Errorf("problem parsing FPM url %q: %v", fpmURL, err)
 			panic(err)
 		}
 		logger.Infof("Using FPM runtime at %q", parsedURL)
-		performer.fpm = gofast.SimpleClientFactory(gofast.SimpleConnFactory(parsedURL.Scheme, parsedURL.Path))
+		proto := parsedURL.Scheme
+		address := parsedURL.Host
+		if proto == "unix" {
+			address = parsedURL.Path
+		}
+		performer.fpm = gofast.SimpleClientFactory(gofast.SimpleConnFactory(proto, address))
 	}
 
 	return performer


### PR DESCRIPTION
Because we have plans to add the Cron Control Runner into Dev Env (Automattic/vip-container-images#783), it would be nice if the runner could connect to a `tcp` socket (`nginx` needs `tcp` to connect to a different container, and `php-fpm` does not support multiple listeners for the same process pool).

This PR adds support for `tcp:`, `tcp4:`, and `tcp6:` sockets.

It was tested in the dev env:

```
root@ccab9ede2bf0:/app# /usr/bin/cron-control-runner -fpm-url tcp://127.0.0.1:9000 -wp-cli-path /usr/local/bin/wp -wp-path /wp -prom-metrics-address :4444 -debug
2024/06/20 03:48:56 Initializing metrics
2024/06/20 03:48:56 INFO: Using FPM runtime at "tcp://127.0.0.1:9000"
2024/06/20 03:48:56 INFO: cron runner has started all processes, running with debug mode set to true
2024/06/20 03:48:56 Listening for metrics on ":4444"
2024/06/20 03:48:56 DEBUG: starting thread "http://vip-local.vipdev.lndo.site"
2024/06/20 03:48:56 INFO: starting watcher for site {URL:http://vip-local.vipdev.lndo.site}, initial delay: 5.754629049s
2024/06/20 03:49:02 DEBUG: initial delay has elapsed for {URL:http://vip-local.vipdev.lndo.site}, starting to run events
2024/06/20 03:49:02 DEBUG: getEvents: got 0 events for site http://vip-local.vipdev.lndo.site
2024/06/20 03:49:30 DEBUG: getEvents: got 1 events for site http://vip-local.vipdev.lndo.site
2024/06/20 03:49:31 DEBUG: runEvents: worker-8 finished job event(url="http://vip-local.vipdev.lndo.site", ts=1718855359, action="7715f1b533e885efdb5e3ef10d2ba3e8", instance="40cd750bba9870f18aada2478b24840a") after 46.282562ms
2024/06/20 03:50:02 DEBUG: getEvents: got 0 events for site http://vip-local.vipdev.lndo.site
2024/06/20 03:50:32 DEBUG: getEvents: got 0 events for site http://vip-local.vipdev.lndo.site
2024/06/20 03:51:04 DEBUG: getEvents: got 0 events for site http://vip-local.vipdev.lndo.site
2024/06/20 03:51:35 DEBUG: getEvents: got 3 events for site http://vip-local.vipdev.lndo.site
2024/06/20 03:51:35 DEBUG: runEvents: worker-7 finished job event(url="http://vip-local.vipdev.lndo.site", ts=1718855479, action="7715f1b533e885efdb5e3ef10d2ba3e8", instance="40cd750bba9870f18aada2478b24840a") after 36.105326ms
2024/06/20 03:51:35 DEBUG: runEvents: worker-6 finished job event(url="http://vip-local.vipdev.lndo.site", ts=1718855479, action="29ef625a054a0b386093ac9c46a2c616", instance="40cd750bba9870f18aada2478b24840a") after 42.646596ms
2024/06/20 03:51:35 DEBUG: runEvents: worker-5 finished job event(url="http://vip-local.vipdev.lndo.site", ts=1718855479, action="3ff9331542b8cdbaae37688e538b5104", instance="40cd750bba9870f18aada2478b24840a") after 46.852341ms
```
