### PR TITLE
ci: update test workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,19 +9,10 @@ jobs:
   build_and_test:
     runs-on: ubuntu-latest
     steps:
-      - name: Cache Go Dependencies
-        # https://github.com/actions/setup-go/issues/130
-        # See: https://github.com/actions/cache/blob/95f200e41cfa87b8e07f30196c0df17a67e67786/examples.md#go---modules
-        uses: actions/cache@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+          go-version-file: go.mod
       - run: go version
       - run: go build
       - run: go test ./...


### PR DESCRIPTION
This PR updates the `test` workflow:
* updates actions to their latest versions;
* removes the "cache Go Dependencies" step because `actions/setup-go@v5` [does it automatically](https://github.com/actions/setup-go/blob/v5/README.md#caching-dependency-files-and-build-outputs).
