### PR TITLE
Print WPCLI output (both stdout/stderr) to wp-cron-runner stream

### DIFF
--- a/remote/remote.go
+++ b/remote/remote.go
@@ -912,6 +912,8 @@ func runWpCliCmdRemote(conn net.Conn, GUID string, rows uint16, cols uint16, wpC
 				continue
 			}
 
+			log.Printf("WP-CLI output: %s", string(buf[:read]))
+
 			atomic.AddInt64(&wpcli.BytesLogged, int64(read))
 
 			written, err = logFile.Write(buf[:read])


### PR DESCRIPTION
Re: @rinatkhaziev and @rebeccahum 's question - The wp-cron-runner invokes WP-CLI commands from within inside the container.

The virtual pty inside the golang program logs the output to a temporary file and then reads the log through the TCP stream back through vip-cli -- However the effective k8s/internal logging (and thus dashboard) logs are lost as WPCLI is not invoked through the `php-fpm` sock/container.  That batch PHP-FPM container is the only container used for the client dashboard logs.

This commit will print the WP-CLI output (both stdout and stderr) to the log stream of the `wp-cron-runner` container and thus they will be available in ELK. 

However they will still *not be shipped* to customers unless Parker is modified to consume the `wp-cron-runner` log stream from K8s.  This log stream is already not designed to be customer facing so would need to be filtered (only look at lines beginning with WP-CLI output). 

Or -- we update our documentation that errors from WP CLI commands are not included in logs/log streams. 