### PR TITLE
feat(devcontainer): install `uuid-runtime` to get `uuidgen`

### DIFF
--- a/.devcontainer/local-features/cron-runner-environment/install.sh
+++ b/.devcontainer/local-features/cron-runner-environment/install.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 apt-get update
-apt-get install -y telnet netcat-openbsd
+apt-get install -y telnet netcat-openbsd uuid-runtime
 rm -rf /var/lib/apt/lists/*
 
 install -D -m 0644 -o root -g root fpm-cron-runner.php /var/wpvip/fpm-cron-runner.php


### PR DESCRIPTION
This simplifies testing; you can now use something like

```sh
echo -e "xxx;$(uuidgen);53;206;option  set \n xxx \"a\nc\"" | nc 127.0.0.1 2212
```
