### PR TITLE
fix: allow embedded newlines in arguments

### DIFF
--- a/remote/remote.go
+++ b/remote/remote.go
@@ -348,20 +348,12 @@ func authenticateProtocolHeader2(data []byte) (string, string, uint16, uint16, i
 }
 
 func validateCommand(calledCmd string) (string, error) {
-	if 0 == len(strings.TrimSpace(calledCmd)) {
-		return "", errors.New("No WP CLI command specified")
+	trimmed := strings.TrimSpace(calledCmd)
+	if len(trimmed) == 0 {
+		return "", errors.New("no WP CLI command specified")
 	}
 
-	cmdParts := strings.Fields(strings.TrimSpace(calledCmd))
-	if 0 == len(cmdParts) {
-		return "", errors.New("WP CLI command not sent")
-	}
-
-	if 1 == len(cmdParts) {
-		return strings.TrimSpace(cmdParts[0]), nil
-	}
-
-	return strings.Join(cmdParts, " "), nil
+	return trimmed, nil
 }
 
 func getCleanWpCliArgumentArray(wpCliCmdString string) []string {


### PR DESCRIPTION
This PR updates `validateCommand()` to allow for whitespace characters in the arguments.

`validateCommand()` used to merge consecutive whitespace characters and replace them with the space character. This broke things when we needed to pass multiple whitespace characters (e.g., preformatted text) or embed a newline character.

Test:
```sh
go build && ./cron-control-runner -token xxx
```

```
$ echo -e "xxx;$(uuidgen);53;206;option  set \n xxx \"a\nb\"" | nc 127.0.0.1 22122
Success: Updated 'xxx' option.

$ wp option get xxx
a
b
```

~⚠️ the base branch for this PR is `BB8-12231` (#32) because it relies upon the new logic in `tokenizeString` introduced in that PR.~
