### PR TITLE
refactor: enhances the reusability of the `remote` package

### DIFF
--- a/remote/events.go
+++ b/remote/events.go
@@ -15,11 +15,15 @@ import (
 
 const (
 	CommandCompletedType = "command-completed"
+	CommandRunningType   = "command-running"
+	CommandErroredType   = "command-errored"
+	CommandCanceledType  = "command-canceled"
+	CommandHeartbeatType = "command-heartbeat"
 )
 
-type event interface {
-	guid() string
-	eventType() string
+type Event interface {
+	GUIDValue() string
+	EventTypeValue() string
 }
 
 type Clock interface {
@@ -30,7 +34,7 @@ type realClock struct{}
 
 func (realClock) Now() time.Time { return time.Now() }
 
-type commandCompleted struct {
+type CommandCompleted struct {
 	GUID      string `json:"guid"`
 	EventType string `json:"event"`
 	Timestamp int64  `json:"timestamp"`
@@ -38,33 +42,33 @@ type commandCompleted struct {
 	Success   bool   `json:"success"`
 }
 
-func (c commandCompleted) guid() string {
+func (c CommandCompleted) GUIDValue() string {
 	return c.GUID
 }
 
-func (c commandCompleted) eventType() string {
+func (c CommandCompleted) EventTypeValue() string {
 	return c.EventType
 }
 
-type eventSender interface {
-	send(ctx context.Context, e event) error
+type EventSender interface {
+	Send(ctx context.Context, e Event) error
 }
 
-type webhookSender struct {
+type WebhookSender struct {
 	httpClient *http.Client
 	endpoint   string
 	token      string
 }
 
-func NewWebhookSender(client *http.Client, endpoint string, token string) *webhookSender {
-	return &webhookSender{
+func NewWebhookSender(client *http.Client, endpoint string, token string) *WebhookSender {
+	return &WebhookSender{
 		httpClient: client,
 		endpoint:   endpoint,
 		token:      token,
 	}
 }
 
-func (sender *webhookSender) send(ctx context.Context, e event) error {
+func (sender *WebhookSender) Send(ctx context.Context, e Event) error {
 	jsonData, err := json.Marshal(e)
 	if err != nil {
 		return fmt.Errorf("webhookSender failed to marshal event: %w", err)
@@ -99,14 +103,14 @@ func (sender *webhookSender) send(ctx context.Context, e event) error {
 	return fmt.Errorf("webhookSender webhook not accepted. Status Code: %d; Body: %s", response.StatusCode, string(body))
 }
 
-type nopSender struct {
+type NopSender struct {
 }
 
-func NewNopSender() *nopSender {
-	return &nopSender{}
+func NewNopSender() *NopSender {
+	return &NopSender{}
 }
 
-func (sender *nopSender) send(ctx context.Context, e event) error {
+func (sender *NopSender) Send(ctx context.Context, e Event) error {
 	return nil
 }
 

--- a/remote/events_test.go
+++ b/remote/events_test.go
@@ -32,7 +32,7 @@ func getSignatureFromHeader(signature string) []byte {
 func TestWebhookSender(t *testing.T) {
 	t.Run("OK", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			var aux commandCompleted
+			var aux CommandCompleted
 
 			body, _ := io.ReadAll(r.Body)
 
@@ -78,7 +78,7 @@ func TestWebhookSender(t *testing.T) {
 			token,
 		)
 
-		err := wpCliEventSender.send(context.Background(), commandCompleted{
+		err := wpCliEventSender.Send(context.Background(), CommandCompleted{
 			GUID:      "123",
 			EventType: CommandCompletedType,
 			Timestamp: expectedTimestamp,
@@ -97,7 +97,7 @@ func TestWebhookSender(t *testing.T) {
 			token,
 		)
 
-		err := wpCliEventSender.send(context.Background(), commandCompleted{
+		err := wpCliEventSender.Send(context.Background(), CommandCompleted{
 			GUID:      "123",
 			EventType: CommandCompletedType,
 			Timestamp: expectedTimestamp,
@@ -122,7 +122,7 @@ func TestWebhookSender(t *testing.T) {
 			token,
 		)
 
-		err := wpCliEventSender.send(context.Background(), commandCompleted{
+		err := wpCliEventSender.Send(context.Background(), CommandCompleted{
 			GUID:      "123",
 			EventType: CommandCompletedType,
 			Timestamp: expectedTimestamp,
@@ -137,7 +137,7 @@ func TestWebhookSender(t *testing.T) {
 }
 
 func TestSignRequestBody(t *testing.T) {
-	body, err := json.Marshal(commandCompleted{
+	body, err := json.Marshal(CommandCompleted{
 		GUID:      "123",
 		EventType: CommandCompletedType,
 		Timestamp: expectedTimestamp,

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -68,7 +68,7 @@ type config struct {
 }
 
 var remoteConfig config
-var wpCliEventSender eventSender
+var wpCliEventSender EventSender
 
 // Setup configures the module (not super ideal, but this module needs some reworking to make it better)
 func Setup(remoteToken string, useWebsockets bool, wpCLIPath string, wpPath string, eventsWebhookURL string) {
@@ -85,7 +85,7 @@ func Setup(remoteToken string, useWebsockets bool, wpCLIPath string, wpPath stri
 	)
 }
 
-func setupWebhookSender(remoteToken string, eventsWebhookURL string) eventSender {
+func setupWebhookSender(remoteToken string, eventsWebhookURL string) EventSender {
 	if eventsWebhookURL != "" {
 		retryClient := retryablehttp.NewClient()
 		retryClient.RetryMax = 10
@@ -946,7 +946,7 @@ func runWpCliCmdRemote(conn net.Conn, GUID string, rows uint16, cols uint16, wpC
 	log.Printf("runWpCliCmdRemote: comand finished: %s\n", GUID)
 
 	go func() {
-		err = wpCliEventSender.send(context.Background(), commandCompleted{
+		err = wpCliEventSender.Send(context.Background(), CommandCompleted{
 			GUID:      GUID,
 			EventType: CommandCompletedType,
 			Timestamp: time.Now().Unix(),


### PR DESCRIPTION
# Description

This PR enhances the reusability of the `remote` package by making its event-related functions and definitions publicly accessible. Currently, these events are internal-only, which creates duplication and limits interoperability for other packages that need to emit or handle the same events.
