### PR TITLE
chore: update base image for devcontainer to 1.25

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
 	"name": "Go",
-	"image": "mcr.microsoft.com/devcontainers/go:1-1.22-bookworm",
+	"image": "mcr.microsoft.com/devcontainers/go:1.25-bookworm",
 	"forwardPorts": [80, 4444],
 	"features": {
 		"ghcr.io/devcontainers/features/github-cli:": {},


### PR DESCRIPTION
This commit updates the base image for the development container to Go 1.25.

The previous image was using Go 1.22, which is past its EoL.

Also, the previous image now fails to build due to unavailable public keys for package repositories.
