### PR TITLE
fix: strip UTF-8 BOM and leading whitespace before JSON decode

### DIFF
--- a/performer/cli.go
+++ b/performer/cli.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/Automattic/cron-control-runner/logger"
 	"github.com/Automattic/cron-control-runner/metrics"
@@ -115,6 +116,7 @@ func (perf *CLI) getMultisiteSites() (Sites, error) {
 	if err != nil {
 		return sites, err
 	}
+	raw = sanitizeJSONInput(raw)
 
 	jsonRes := make([]Site, 0)
 	if err = json.Unmarshal([]byte(raw), &jsonRes); err != nil {
@@ -136,6 +138,7 @@ func (perf *CLI) getSiteInfo() (siteInfo, error) {
 	if err != nil {
 		return siteInfo{}, err
 	}
+	raw = sanitizeJSONInput(raw)
 
 	jsonRes := make([]siteInfo, 0)
 	if err = json.Unmarshal([]byte(raw), &jsonRes); err != nil {
@@ -153,6 +156,7 @@ func (perf *CLI) GetEvents(site Site) ([]Event, error) {
 	if err != nil {
 		return emptyEvents, err
 	}
+	raw = sanitizeJSONInput(raw)
 
 	siteEvents := make([]Event, 0)
 	if err = json.Unmarshal([]byte(raw), &siteEvents); err != nil {
@@ -271,6 +275,7 @@ func (perf *CLI) processCommandWithFPM(subcommand []string) (string, error) {
 	if hrw.LastStatus != http.StatusOK {
 		return "", fmt.Errorf("fpm error: lastStatus=%d, headers=%v, stdout=%q, stderr=%q", hrw.LastStatus, hrw.Headers, stdOutStr, stdErr.String())
 	}
+	stdOutStr = sanitizeJSONInput(stdOutStr)
 
 	var res struct {
 		Buf    string `json:"buf"`
@@ -300,6 +305,15 @@ func (perf *CLI) processCommandWithFPM(subcommand []string) (string, error) {
 	}
 
 	return res.Buf, err
+}
+
+func sanitizeJSONInput(input string) string {
+	// Some upstream environments occasionally prepend a UTF-8 BOM and/or whitespace.
+	// Strip both so JSON decoding starts at the first JSON token.
+	input = strings.TrimLeftFunc(input, unicode.IsSpace)
+	input = strings.TrimPrefix(input, "\uFEFF")
+	input = strings.TrimLeftFunc(input, unicode.IsSpace)
+	return input
 }
 
 func (perf *CLI) buildFpmQuery(subcommand []string) (url.Values, error) {

--- a/performer/cli.go
+++ b/performer/cli.go
@@ -116,7 +116,6 @@ func (perf *CLI) getMultisiteSites() (Sites, error) {
 	if err != nil {
 		return sites, err
 	}
-	raw = sanitizeJSONInput(raw)
 
 	jsonRes := make([]Site, 0)
 	if err = json.Unmarshal([]byte(raw), &jsonRes); err != nil {
@@ -138,7 +137,6 @@ func (perf *CLI) getSiteInfo() (siteInfo, error) {
 	if err != nil {
 		return siteInfo{}, err
 	}
-	raw = sanitizeJSONInput(raw)
 
 	jsonRes := make([]siteInfo, 0)
 	if err = json.Unmarshal([]byte(raw), &jsonRes); err != nil {
@@ -156,7 +154,6 @@ func (perf *CLI) GetEvents(site Site) ([]Event, error) {
 	if err != nil {
 		return emptyEvents, err
 	}
-	raw = sanitizeJSONInput(raw)
 
 	siteEvents := make([]Event, 0)
 	if err = json.Unmarshal([]byte(raw), &siteEvents); err != nil {
@@ -187,11 +184,12 @@ func (perf *CLI) runWpCmd(command []string) (string, error) {
 		t0 := time.Now()
 		result, err := perf.processCommandWithFPM(command)
 		perf.metrics.RecordFpmTiming(err == nil, time.Since(t0))
-		return result, err
+		return sanitizeJSONInput(result), err
 	}
 
 	// Non-FPM CLI, useful for local dev-env setups.
-	return perf.processCommand(command)
+	result, err := perf.processCommand(command)
+	return sanitizeJSONInput(result), err
 }
 
 func (perf *CLI) processCommand(command []string) (string, error) {

--- a/performer/cli.go
+++ b/performer/cli.go
@@ -184,12 +184,12 @@ func (perf *CLI) runWpCmd(command []string) (string, error) {
 		t0 := time.Now()
 		result, err := perf.processCommandWithFPM(command)
 		perf.metrics.RecordFpmTiming(err == nil, time.Since(t0))
-		return sanitizeJSONInput(result), err
+		return trimJSONPreamble(result), err
 	}
 
 	// Non-FPM CLI, useful for local dev-env setups.
 	result, err := perf.processCommand(command)
-	return sanitizeJSONInput(result), err
+	return trimJSONPreamble(result), err
 }
 
 func (perf *CLI) processCommand(command []string) (string, error) {
@@ -273,7 +273,7 @@ func (perf *CLI) processCommandWithFPM(subcommand []string) (string, error) {
 	if hrw.LastStatus != http.StatusOK {
 		return "", fmt.Errorf("fpm error: lastStatus=%d, headers=%v, stdout=%q, stderr=%q", hrw.LastStatus, hrw.Headers, stdOutStr, stdErr.String())
 	}
-	stdOutStr = sanitizeJSONInput(stdOutStr)
+	stdOutStr = trimJSONPreamble(stdOutStr)
 
 	var res struct {
 		Buf    string `json:"buf"`
@@ -305,13 +305,10 @@ func (perf *CLI) processCommandWithFPM(subcommand []string) (string, error) {
 	return res.Buf, err
 }
 
-func sanitizeJSONInput(input string) string {
-	// Some upstream environments occasionally prepend a UTF-8 BOM and/or whitespace.
-	// Strip both so JSON decoding starts at the first JSON token.
-	input = strings.TrimLeftFunc(input, unicode.IsSpace)
-	input = strings.TrimPrefix(input, "\uFEFF")
-	input = strings.TrimLeftFunc(input, unicode.IsSpace)
-	return input
+func trimJSONPreamble(input string) string {
+	return strings.TrimLeftFunc(input, func(r rune) bool {
+		return r == '\uFEFF' || unicode.IsSpace(r)
+	})
 }
 
 func (perf *CLI) buildFpmQuery(subcommand []string) (url.Values, error) {

--- a/performer/performer_test.go
+++ b/performer/performer_test.go
@@ -70,7 +70,7 @@ func TestSanitizeJSONInput(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := sanitizeJSONInput(tt.input)
+			got := trimJSONPreamble(tt.input)
 			if got != tt.want {
 				t.Fatalf("sanitizeJSONInput() = %q, want %q", got, tt.want)
 			}

--- a/performer/performer_test.go
+++ b/performer/performer_test.go
@@ -39,3 +39,41 @@ func TestEvent_LockKey(t *testing.T) {
 		})
 	}
 }
+
+func TestSanitizeJSONInput(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "plain json unchanged",
+			input: `[{"url":"https://example.com"}]`,
+			want:  `[{"url":"https://example.com"}]`,
+		},
+		{
+			name:  "strips bom",
+			input: "\uFEFF[{\"url\":\"https://example.com\"}]",
+			want:  `[{"url":"https://example.com"}]`,
+		},
+		{
+			name:  "strips leading whitespace",
+			input: " \n\t[{\"url\":\"https://example.com\"}]",
+			want:  `[{"url":"https://example.com"}]`,
+		},
+		{
+			name:  "strips whitespace then bom",
+			input: " \n\t\uFEFF[{\"url\":\"https://example.com\"}]",
+			want:  `[{"url":"https://example.com"}]`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sanitizeJSONInput(tt.input)
+			if got != tt.want {
+				t.Fatalf("sanitizeJSONInput() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Some upstream environments prepend a UTF-8 BOM (EF BB BF) or extra whitespace to WP-CLI/FPM output, causing json.Unmarshal to fail with "invalid character 'ï' looking for beginning of value".

Add sanitizeJSONInput() to trim leading whitespace and the BOM before decoding in getMultisiteSites, getSiteInfo, GetEvents, and the FPM response path.