### PR TITLE
fix: timing attack on auth token comparison

### DIFF
--- a/remote/remote.go
+++ b/remote/remote.go
@@ -8,6 +8,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"crypto/subtle"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -231,7 +232,7 @@ func authConn(conn net.Conn) {
 		return
 	}
 
-	if token != remoteConfig.remoteToken {
+	if subtle.ConstantTimeCompare([]byte(token), []byte(remoteConfig.remoteToken)) != 1 {
 		conn.Write([]byte("invalid auth handshake"))
 		log.Printf("error incorrect handshake string")
 		conn.Close()

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -62,7 +62,6 @@ var (
 )
 
 type config struct {
-	remoteToken   string
 	remoteTokenB  []byte
 	useWebsockets bool
 	wpCLIPath     string
@@ -75,7 +74,6 @@ var wpCliEventSender EventSender
 // Setup configures the module (not super ideal, but this module needs some reworking to make it better)
 func Setup(remoteToken string, useWebsockets bool, wpCLIPath string, wpPath string, eventsWebhookURL string) {
 	remoteConfig = config{
-		remoteToken:   remoteToken,
 		remoteTokenB:  []byte(remoteToken),
 		useWebsockets: useWebsockets,
 		wpCLIPath:     wpCLIPath,
@@ -207,7 +205,7 @@ func authConn(conn net.Conn) {
 	log.Printf("size of handshake %d\n", size)
 
 	// This is the minimum size to determine the protocol type
-	if size < len(remoteConfig.remoteToken)+gGUIDLength {
+	if size < len(remoteConfig.remoteTokenB)+gGUIDLength {
 		conn.Write([]byte("Error negotiating handshake"))
 		log.Println("error negotiating the handshake")
 		conn.Close()
@@ -220,7 +218,7 @@ func authConn(conn net.Conn) {
 	}
 
 	// Determine if the packet structure is the new version or not
-	if ';' != data[len(remoteConfig.remoteToken)] {
+	if ';' != data[len(remoteConfig.remoteTokenB)] {
 		token, GUID, rows, cols, offset, cmd, err = authenticateProtocolHeader2(data[:size-newlineChars])
 	} else {
 		token, GUID, rows, cols, cmd, err = authenticateProtocolHeader1(string(data[:size-newlineChars]))
@@ -296,8 +294,8 @@ func authenticateProtocolHeader1(dataString string) (string, string, uint16, uin
 	}
 
 	token = elems[0]
-	if len(token) != len(remoteConfig.remoteToken) {
-		return "", "", 0, 0, "", fmt.Errorf("error incorrect handshake reply size: %d != %d", len(remoteConfig.remoteToken), len(elems[0]))
+	if len(token) != len(remoteConfig.remoteTokenB) {
+		return "", "", 0, 0, "", fmt.Errorf("error incorrect handshake reply size: %d != %d", len(remoteConfig.remoteTokenB), len(elems[0]))
 	}
 
 	guid = elems[1]
@@ -324,30 +322,30 @@ func authenticateProtocolHeader2(data []byte) (string, string, uint16, uint16, i
 	var offset uint64
 	var err error
 
-	if len(data) < len(remoteConfig.remoteToken)+gGUIDLength+4+4+8 {
+	if len(data) < len(remoteConfig.remoteTokenB)+gGUIDLength+4+4+8 {
 		return "", "", 0, 0, 0, "", errors.New("error negotiating the v2 protocol handshake")
 	}
 
-	token = string(data[:len(remoteConfig.remoteToken)])
-	guid = string(data[len(remoteConfig.remoteToken) : len(remoteConfig.remoteToken)+gGUIDLength])
+	token = string(data[:len(remoteConfig.remoteTokenB)])
+	guid = string(data[len(remoteConfig.remoteTokenB) : len(remoteConfig.remoteTokenB)+gGUIDLength])
 
 	if !guidRegex.Match([]byte(guid)) {
 		return "", "", 0, 0, 0, "", errors.New("error incorrect GUID format")
 	}
 
-	rows, err = strconv.ParseUint(string(data[len(remoteConfig.remoteToken)+gGUIDLength:len(remoteConfig.remoteToken)+gGUIDLength+4]), 10, 16)
+	rows, err = strconv.ParseUint(string(data[len(remoteConfig.remoteTokenB)+gGUIDLength:len(remoteConfig.remoteTokenB)+gGUIDLength+4]), 10, 16)
 	if nil != err {
 		return "", "", 0, 0, 0, "", fmt.Errorf("error incorrect console rows setting: %s", err.Error())
 	}
 
-	cols, err = strconv.ParseUint(string(data[len(remoteConfig.remoteToken)+gGUIDLength+4:len(remoteConfig.remoteToken)+gGUIDLength+4+4]), 10, 16)
+	cols, err = strconv.ParseUint(string(data[len(remoteConfig.remoteTokenB)+gGUIDLength+4:len(remoteConfig.remoteTokenB)+gGUIDLength+4+4]), 10, 16)
 	if nil != err {
 		return "", "", 0, 0, 0, "", fmt.Errorf("error incorrect console columns setting: %s", err.Error())
 	}
 
-	offset = binary.LittleEndian.Uint64(data[len(remoteConfig.remoteToken)+gGUIDLength+4+4 : len(remoteConfig.remoteToken)+gGUIDLength+4+4+8])
+	offset = binary.LittleEndian.Uint64(data[len(remoteConfig.remoteTokenB)+gGUIDLength+4+4 : len(remoteConfig.remoteTokenB)+gGUIDLength+4+4+8])
 
-	return token, guid, uint16(rows), uint16(cols), int64(offset), string(data[len(remoteConfig.remoteToken)+gGUIDLength+4+4+8:]), nil
+	return token, guid, uint16(rows), uint16(cols), int64(offset), string(data[len(remoteConfig.remoteTokenB)+gGUIDLength+4+4+8:]), nil
 }
 
 func validateCommand(calledCmd string) (string, error) {

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -173,6 +173,13 @@ func authConn(conn net.Conn) {
 
 	log.Println("waiting for auth data")
 
+	if len(remoteConfig.remoteTokenB) == 0 {
+		conn.Write([]byte("invalid auth handshake"))
+		log.Printf("error remote token is not configured")
+		conn.Close()
+		return
+	}
+
 	conn.SetReadDeadline(time.Now().Add(time.Duration(5000 * time.Millisecond.Nanoseconds())))
 	bufReader := bufio.NewReader(conn)
 

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -63,6 +63,7 @@ var (
 
 type config struct {
 	remoteToken   string
+	remoteTokenB  []byte
 	useWebsockets bool
 	wpCLIPath     string
 	wpPath        string
@@ -75,6 +76,7 @@ var wpCliEventSender EventSender
 func Setup(remoteToken string, useWebsockets bool, wpCLIPath string, wpPath string, eventsWebhookURL string) {
 	remoteConfig = config{
 		remoteToken:   remoteToken,
+		remoteTokenB:  []byte(remoteToken),
 		useWebsockets: useWebsockets,
 		wpCLIPath:     wpCLIPath,
 		wpPath:        wpPath,
@@ -232,7 +234,7 @@ func authConn(conn net.Conn) {
 		return
 	}
 
-	if subtle.ConstantTimeCompare([]byte(token), []byte(remoteConfig.remoteToken)) != 1 {
+	if subtle.ConstantTimeCompare([]byte(token), remoteConfig.remoteTokenB) != 1 {
 		conn.Write([]byte("invalid auth handshake"))
 		log.Printf("error incorrect handshake string")
 		conn.Close()

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -1,8 +1,12 @@
 package remote
 
 import (
+	"net"
 	"reflect"
+	"regexp"
+	"sync"
 	"testing"
+	"time"
 )
 
 func TestValidateCommand(t *testing.T) {
@@ -93,5 +97,46 @@ func TestGetCleanWpCliArgumentArray(t *testing.T) {
 				t.Fatalf("testing '%v' getCleanWpCliArgumentArray(\"%v\") expected: %v, got: %v", name, tc.input, tc.want, got)
 			}
 		})
+	}
+}
+
+func TestAuthConnRejectsInvalidToken(t *testing.T) {
+	remoteConfig = config{remoteToken: "supersecrettoken"}
+	guidRegex = regexp.MustCompile(`^[a-fA-F0-9\-]+$`)
+	gGUIDttys = make(map[string]*wpCLIProcess)
+	padlock = &sync.Mutex{}
+
+	serverConn, clientConn := net.Pipe()
+	t.Cleanup(func() {
+		clientConn.Close()
+		serverConn.Close()
+	})
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		authConn(serverConn)
+	}()
+
+	handshake := "xupersecrettoken;123e4567-e89b-12d3-a456-426614174000;24;80;vip whatever\n"
+	if _, err := clientConn.Write([]byte(handshake)); err != nil {
+		t.Fatalf("failed to write handshake: %v", err)
+	}
+
+	buf := make([]byte, 256)
+	_ = clientConn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	n, err := clientConn.Read(buf)
+	if err != nil {
+		t.Fatalf("failed to read auth response: %v", err)
+	}
+
+	if got := string(buf[:n]); got != "invalid auth handshake" {
+		t.Fatalf("expected invalid auth handshake, got %q", got)
+	}
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("authConn did not terminate")
 	}
 }

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -160,3 +160,59 @@ func TestAuthConnRejectsInvalidToken(t *testing.T) {
 		t.Fatal("authConn did not terminate")
 	}
 }
+
+func TestAuthConnRejectsEmptyConfiguredToken(t *testing.T) {
+	done := make(chan struct{})
+
+	prevConfig := remoteConfig
+	prevGuidRegex := guidRegex
+	prevGUIDttys := gGUIDttys
+	prevPadlock := padlock
+	t.Cleanup(func() {
+		remoteConfig = prevConfig
+		guidRegex = prevGuidRegex
+		gGUIDttys = prevGUIDttys
+		padlock = prevPadlock
+	})
+
+	remoteConfig = config{remoteTokenB: []byte("")}
+	guidRegex = regexp.MustCompile(`^[a-fA-F0-9\-]+$`)
+	gGUIDttys = make(map[string]*wpCLIProcess)
+	padlock = &sync.Mutex{}
+
+	serverConn, clientConn := net.Pipe()
+	t.Cleanup(func() {
+		_ = clientConn.Close()
+		_ = serverConn.Close()
+
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Error("authConn did not terminate during cleanup")
+		}
+	})
+
+	go func() {
+		defer close(done)
+		authConn(serverConn)
+	}()
+
+	buf := make([]byte, 256)
+	if err := clientConn.SetReadDeadline(time.Now().Add(2 * time.Second)); err != nil {
+		t.Fatalf("failed to set read deadline: %v", err)
+	}
+	n, err := clientConn.Read(buf)
+	if err != nil {
+		t.Fatalf("failed to read auth response: %v", err)
+	}
+
+	if got := string(buf[:n]); got != "invalid auth handshake" {
+		t.Fatalf("expected invalid auth handshake, got %q", got)
+	}
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("authConn did not terminate")
+	}
+}

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -101,7 +101,18 @@ func TestGetCleanWpCliArgumentArray(t *testing.T) {
 }
 
 func TestAuthConnRejectsInvalidToken(t *testing.T) {
-	remoteConfig = config{remoteToken: "supersecrettoken", remoteTokenB: []byte("supersecrettoken")}
+	prevConfig := remoteConfig
+	prevGuidRegex := guidRegex
+	prevGUIDttys := gGUIDttys
+	prevPadlock := padlock
+	t.Cleanup(func() {
+		remoteConfig = prevConfig
+		guidRegex = prevGuidRegex
+		gGUIDttys = prevGUIDttys
+		padlock = prevPadlock
+	})
+
+	remoteConfig = config{remoteTokenB: []byte("supersecrettoken")}
 	guidRegex = regexp.MustCompile(`^[a-fA-F0-9\-]+$`)
 	gGUIDttys = make(map[string]*wpCLIProcess)
 	padlock = &sync.Mutex{}
@@ -124,7 +135,9 @@ func TestAuthConnRejectsInvalidToken(t *testing.T) {
 	}
 
 	buf := make([]byte, 256)
-	_ = clientConn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	if err := clientConn.SetReadDeadline(time.Now().Add(2 * time.Second)); err != nil {
+		t.Fatalf("failed to set read deadline: %v", err)
+	}
 	n, err := clientConn.Read(buf)
 	if err != nil {
 		t.Fatalf("failed to read auth response: %v", err)

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -101,7 +101,7 @@ func TestGetCleanWpCliArgumentArray(t *testing.T) {
 }
 
 func TestAuthConnRejectsInvalidToken(t *testing.T) {
-	remoteConfig = config{remoteToken: "supersecrettoken"}
+	remoteConfig = config{remoteToken: "supersecrettoken", remoteTokenB: []byte("supersecrettoken")}
 	guidRegex = regexp.MustCompile(`^[a-fA-F0-9\-]+$`)
 	gGUIDttys = make(map[string]*wpCLIProcess)
 	padlock = &sync.Mutex{}

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -101,6 +101,8 @@ func TestGetCleanWpCliArgumentArray(t *testing.T) {
 }
 
 func TestAuthConnRejectsInvalidToken(t *testing.T) {
+	done := make(chan struct{})
+
 	prevConfig := remoteConfig
 	prevGuidRegex := guidRegex
 	prevGUIDttys := gGUIDttys
@@ -119,11 +121,16 @@ func TestAuthConnRejectsInvalidToken(t *testing.T) {
 
 	serverConn, clientConn := net.Pipe()
 	t.Cleanup(func() {
-		clientConn.Close()
-		serverConn.Close()
+		_ = clientConn.Close()
+		_ = serverConn.Close()
+
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Error("authConn did not terminate during cleanup")
+		}
 	})
 
-	done := make(chan struct{})
 	go func() {
 		defer close(done)
 		authConn(serverConn)


### PR DESCRIPTION
The remote authentication mechanism compares the client-supplied token against the configured secret using Go's `!=` operator, which is not constant-time.

Go's `!=` operator performs lexicographic comparison and short-circuits on the first mismatching byte. An attacker who can make a high volume of connections and measure response latencies can recover the secret token one byte at a time using statistical timing analysis — no brute-force of the full key space is required.

This commit replaces the `!=` operator with `crypto/subtle.ConstantTimeCompare`, which performs a constant-time comparison of the two byte slices, preventing timing attacks.