### PR TITLE
fix: out-of-bounds index in `getSiteInfo`

### DIFF
--- a/performer/cli.go
+++ b/performer/cli.go
@@ -2,6 +2,7 @@ package performer
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"math/rand"
@@ -141,6 +142,10 @@ func (perf *CLI) getSiteInfo() (siteInfo, error) {
 	jsonRes := make([]siteInfo, 0)
 	if err = json.Unmarshal([]byte(raw), &jsonRes); err != nil {
 		return siteInfo{}, err
+	}
+
+	if len(jsonRes) == 0 {
+		return siteInfo{}, errors.New("getSiteInfo: WP-CLI returned empty response")
 	}
 
 	return jsonRes[0], nil

--- a/performer/performer_test.go
+++ b/performer/performer_test.go
@@ -1,6 +1,16 @@
 package performer
 
-import "testing"
+import (
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Automattic/cron-control-runner/logger"
+	"github.com/Automattic/cron-control-runner/metrics"
+)
 
 func TestEvent_LockKey(t *testing.T) {
 	type fields struct {
@@ -75,5 +85,31 @@ func TestSanitizeJSONInput(t *testing.T) {
 				t.Fatalf("sanitizeJSONInput() = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestGetSiteInfo_EmptyJSONArrayReturnsError(t *testing.T) {
+	tmpDir := t.TempDir()
+	wpCLIPath := filepath.Join(tmpDir, "wp")
+
+	script := "#!/bin/sh\nprintf '[]'\n"
+	if err := os.WriteFile(wpCLIPath, []byte(script), 0755); err != nil {
+		t.Fatalf("failed to write fake wp-cli: %v", err)
+	}
+
+	perf := &CLI{
+		wpCLIPath: wpCLIPath,
+		wpPath:    tmpDir,
+		metrics:   metrics.Mock{},
+		logger:    logger.Logger{Logger: log.New(io.Discard, "", 0)},
+	}
+
+	_, err := perf.getSiteInfo()
+	if err == nil {
+		t.Fatal("expected error for empty WP-CLI response, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "empty response") {
+		t.Fatalf("expected empty response error, got: %v", err)
 	}
 }


### PR DESCRIPTION
After unmarshalling WP-CLI JSON responses, the code indexes directly into the result slice without checking its length.

If WP-CLI returns an empty JSON array (`[]`), the service panics with the index-out-of-range error. This crashes the goroutine handling the request.

To fix this, we check if the unmarshalled slice is empty before accessing its first element. If it is empty, we return an error.