### PR TITLE
chore: pin third-party GitHub Actions to SHAs + enable Dependabot github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,14 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
           jq .dsseEnvelope "${{ steps.attest.outputs.bundle-path }}" > bin/cron-control-runner.intoto.jsonl
 
       - name: Create a release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           generate_release_notes: true
           files: |


### PR DESCRIPTION
Two changes in one PR:

1. Pin `softprops/action-gh-release@v2` to a commit SHA (tag preserved as trailing comment) to harden against supply-chain risk on mutable tags.
2. Enable Dependabot for the `github-actions` ecosystem so pinned SHAs get automatic refresh PRs (weekly, grouped).

Tracking: DEVPROD-1072.