### PR TITLE
fix: use supported GitHub Actions Dependabot cooldown config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,4 +25,3 @@ updates:
           - major
     cooldown:
       default-days: 7
-      semver-major-days: 14


### PR DESCRIPTION
Follow-up to https://github.com/Automattic/cron-control-runner/pull/59.

That PR added a per-SemVer Dependabot cooldown key under the `github-actions` ecosystem. GitHub currently supports a flat `cooldown.default-days` setting for GitHub Actions, but not `semver-major-days` / `semver-minor-days` / `semver-patch-days` there.

This removes `semver-major-days: 14` and keeps `cooldown.default-days: 7`, plus the existing major and minor/patch groups.

Tracking: DEVPROD-1072
